### PR TITLE
feat(build): Add support for AWS CodeBuild

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -1,11 +1,9 @@
 version: 0.2
 
 phases:
-  pre_build:
-    commands:
-      - "sudo docker build -t opentrons-buildroot"
   build:
     commands:
+      - "sudo docker build -t opentrons-buildroot"
       - "sudo docker run --mount type=bind,source=$(pwd),destination=/buildroot opentrons-buildroot ot2_defconfig"
       - "sudo docker run --mount type=bind,source=$(pwd),destination=/buildroot opentrons-buildroot all"
 artifacts:

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -3,11 +3,11 @@ version: 0.2
 phases:
   pre_build:
     commands:
-      - "docker build -t opentrons-buildroot"
+      - "sudo docker build -t opentrons-buildroot"
   build:
     commands:
-      - "docker run --mount type=bind,source=$(pwd),destination=/buildroot opentrons-buildroot ot2_defconfig"
-      - "docker run --mount type=bind,source=$(pwd),destination=/buildroot opentrons-buildroot all"
+      - "sudo docker run --mount type=bind,source=$(pwd),destination=/buildroot opentrons-buildroot ot2_defconfig"
+      - "sudo docker run --mount type=bind,source=$(pwd),destination=/buildroot opentrons-buildroot all"
 artifacts:
   files:
     - output/images/sdcard.img

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -1,0 +1,17 @@
+version: 0.2
+
+phases:
+  pre_build:
+    commands:
+      - "docker build -t opentrons-buildroot"
+  build:
+    commands:
+      - "docker run --mount type=bind,source=$(pwd),destination=/buildroot opentrons-buildroot ot2_defconfig"
+      - "docker run --mount type=bind,source=$(pwd),destination=/buildroot opentrons-buildroot all"
+artifacts:
+  files:
+    - output/images/sdcard.img
+    - output/images/rootfs.tar.gz
+    - output/images/rootfs.ext4
+  name: linux-image
+  discard-paths: yes

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -13,5 +13,4 @@ artifacts:
     - output/images/sdcard.img
     - output/images/rootfs.tar.gz
     - output/images/rootfs.ext4
-  name: $CODEBUILD_WEBHOOK_TRIGGER-$CODEBUILD_BUILD_ID
   discard-paths: yes

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -1,11 +1,13 @@
 version: 0.2
 
 phases:
+  pre-build:
+    commands:
+      - "docker build -t opentrons-buildroot ."
   build:
     commands:
-      - "sudo docker build -t opentrons-buildroot"
-      - "sudo docker run --mount type=bind,source=$(pwd),destination=/buildroot opentrons-buildroot ot2_defconfig"
-      - "sudo docker run --mount type=bind,source=$(pwd),destination=/buildroot opentrons-buildroot all"
+      - "docker run --mount type=bind,source=$(pwd),destination=/buildroot opentrons-buildroot ot2_defconfig"
+      - "docker run --mount type=bind,source=$(pwd),destination=/buildroot opentrons-buildroot all"
 artifacts:
   files:
     - output/images/sdcard.img

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -13,5 +13,5 @@ artifacts:
     - output/images/sdcard.img
     - output/images/rootfs.tar.gz
     - output/images/rootfs.ext4
-  name: linux-image
+  name: $CODEBUILD_WEBHOOK_TRIGGER-$CODEBUILD_BUILD_ID
   discard-paths: yes

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -1,7 +1,7 @@
 version: 0.2
 
 phases:
-  pre-build:
+  pre_build:
     commands:
       - "docker build -t opentrons-buildroot ."
   build:


### PR DESCRIPTION
This commit adds a buildspec.yml for use with AWS Codebuild as a hosted CI tool that has limits compatible with buildroot builds.