### PR TITLE
fix(system): write dropbear symlink in code

### DIFF
--- a/board/opentrons/ot2/post-build.sh
+++ b/board/opentrons/ot2/post-build.sh
@@ -41,3 +41,9 @@ export $(cat /buildroot/.env | xargs)
 
 python ./board/opentrons/ot2/write_version.py ${BINARIES_DIR}/opentrons-api-version.json ${BINARIES_DIR}/VERSION.json
 cp ${BINARIES_DIR}/VERSION.json ${TARGET_DIR}/etc/VERSION.json
+
+# Make the symlink for /etc/dropbear->/var/run/dropbear in code because it
+# needs to be absolute to trigger logic in the dropbear systemfile, but when
+# checked in absolute symlinks are rewritten by aws codebuild
+rm -rf ${TARGET_DIR}/etc/dropbear
+ln -s /var/run/dropbear ${TARGET_DIR}/etc/dropbear

--- a/board/opentrons/ot2/rootfs-overlay/etc/dropbear
+++ b/board/opentrons/ot2/rootfs-overlay/etc/dropbear
@@ -1,1 +1,0 @@
-../var/run/dropbear


### PR DESCRIPTION
The dropbear system file checks to see if /etc/dropbear is a symlink to
precisely /var/run/dropbear. Our checked-in symlink is to ../var/run/dropbear,
which fails this test. However, if we make it absolute, codebuild will rewrite
it. So, create it in the postbuild script.