### PR TITLE
feat(build): Support balena migration

### DIFF
--- a/board/opentrons/ot2/genimage-ot2.cfg
+++ b/board/opentrons/ot2/genimage-ot2.cfg
@@ -14,7 +14,7 @@ image boot.vfat {
       "boot.scr"
     }
   }
-  size = 32M
+  size = 40M
 }
 
 image varfs.ext4 {
@@ -24,8 +24,16 @@ image varfs.ext4 {
   size = 100M
 }
 
+image padding.ext4 {
+  ext4 {}
+  name = "padding"
+  size = 20M
+  mountpoint = "/padding"
+}
+
 image sdcard.img {
   hdimage {
+    align = 4M
   }
 
   partition boot {
@@ -42,6 +50,12 @@ image sdcard.img {
   partition rootfs2 {
     partition-type = 0x83
     image = "rootfs.ext4"
+  }
+
+  partition padding {
+    partition-type = 0x83
+    image = "padding.ext4"
+    size = 20M
   }
 
   partition varfs {

--- a/board/opentrons/ot2/post-build.sh
+++ b/board/opentrons/ot2/post-build.sh
@@ -18,10 +18,12 @@ fi
 # Write an fstab that will do our /var and bind mounts
 cat <<EOF > ${TARGET_DIR}/etc/fstab
 /dev/root / auto ro 0 0
-/dev/mmcblk0p4 /var auto rw,x-systemd.growfs 0 2
+/dev/mmcblk0p6 /var auto rw,x-systemd.growfs 0 2
 /var/data /data none defaults,bind 0 0
 /var/home /root none defaults,bind 0 0
 /var/mnt /mnt none defaults,bind 0 0
+/var/hostname /etc/hostname none defaults,bind,nofail 0 0
+/var/machine-info /etc/machine-info none defaults,bind,nofail 0 0
 EOF
 
 # Get our kernel and dt(s) in rootfs
@@ -34,6 +36,7 @@ cp -r ${BINARIES_DIR}/*.dtb ${TARGET_DIR}/boot/
 
 # rewrite config.txt to boot u-boot
 sed -i s/kernel=zImage/kernel=u-boot.bin/ ${BINARIES_DIR}/rpi-firmware/config.txt
+hostname_to_write=$(cat ${TARGET_DIR}/var/hostname)
 
 if [ ${OT_BUILD_TYPE} != "release" ]; then
     echo "Build type is NOT RELEASE, adding default ssh key and removing signing"
@@ -41,8 +44,23 @@ if [ ${OT_BUILD_TYPE} != "release" ]; then
     cat ${TARGET_DIR}/var/home/.ssh/robot_key.pub > ${TARGET_DIR}/var/home/.ssh/authorized_keys
     # remove code signing cert (allows unsigned updates)
     rm ${TARGET_DIR}/etc/opentrons-robot-signing-key.crt
+    deployment_to_write="development"
+
 else
     echo "Build type is RELEASE"
+    deployment_to_write="production"
+fi
+
+
+cat <<EOF >> "${TARGET_DIR}/etc/machine-info"
+PRETTY_HOSTNAME=${hostname_to_write}
+DEPLOYMENT=${deployment_to_write}
+EOF
+
+# Start avahi-daemon as late as possible so it catches hostnamed changing
+# the hostname
+if [[ -f ${TARGET_DIR}/etc/systemd/system/multi-user.target.wants/avahi-daemon.service ]]; then
+    mv ${TARGET_DIR}/etc/systemd/system/multi-user.target.wants/avahi-daemon.service ${TARGET_DIR}/etc/systemd/system/opentrons.target.wants/avahi-daemon.service
 fi
 
 python ./board/opentrons/ot2/write_version.py ${BINARIES_DIR}/opentrons-api-version.json ${BINARIES_DIR}/opentrons-update-server-version.json ${BINARIES_DIR}/VERSION.json

--- a/board/opentrons/ot2/post-build.sh
+++ b/board/opentrons/ot2/post-build.sh
@@ -36,7 +36,7 @@ cp -r ${BINARIES_DIR}/*.dtb ${TARGET_DIR}/boot/
 
 # rewrite config.txt to boot u-boot
 sed -i s/kernel=zImage/kernel=u-boot.bin/ ${BINARIES_DIR}/rpi-firmware/config.txt
-hostname_to_write=$(cat ${TARGET_DIR}/var/hostname)
+hostname_to_write=$(cat ${TARGET_DIR}/etc/hostname)
 
 if [ ${OT_BUILD_TYPE} != "release" ]; then
     echo "Build type is NOT RELEASE, adding default ssh key and removing signing"

--- a/board/opentrons/ot2/post-image.sh
+++ b/board/opentrons/ot2/post-image.sh
@@ -61,6 +61,11 @@ mv "${GENIMAGE_TMP}/var" "${TARGET_DIR}/"
 
 rm -rf "${GENIMAGE_TMP}"
 
+cp ${TARGET_DIR}/etc/hostname ${TARGET_DIR}/var/hostname
+cp ${TARGET_DIR}/etc/machine-info ${TARGET_DIR}/var/machine-info
+
+mkdir -p ${TARGET_DIR}/padding
+
 genimage                           \
 	--rootpath "${TARGET_DIR}"     \
 	--tmppath "${GENIMAGE_TMP}"    \
@@ -70,6 +75,9 @@ genimage                           \
 
 echo "Generating hash for rootfs.ext4..."
 shasum -a 256 ${BINARIES_DIR}/rootfs.ext4 | grep -oh "^.\+ " > ${BINARIES_DIR}/rootfs.ext4.hash
+
+echo "Generating hash for boot.vfat..."
+shasum -a 256 ${BINARIES_DIR}/boot.vfat | grep -oh "^.\+ " > ${BINARIES_DIR}/boot.vfat.hash
 
 if [ ${OT_BUILD_TYPE} = "release" ]; then
     echo "Build type is RELEASE"
@@ -83,11 +91,13 @@ fi
 
 echo "Zipping system image..."
 rm -f ${BINARIES_DIR}/ot2-system.zip
-zip -j ${BINARIES_DIR}/ot2-system.zip ${system_files}
+zip -j ${BINARIES_DIR}/ot2-system.zip ${system_files} ${BINARIES_DIR}/VERSION.json
 
 echo "Zipping full sd card image..."
 rm -f ${BINARIES_DIR}/ot2-fullimage.zip
 zip -j ${BINARIES_DIR}/ot2-fullimage.zip ${BINARIES_DIR}/sdcard.img ${BINARIES_DIR}/VERSION.json
 
-
+echo "Zipping migration image..."
+rm -f ${BINARIES_DIR}/ot2-migration.zip
+zip -j ${BINARIES_DIR}/ot2-migration.zip ${BINARIES_DIR}/rootfs.ext4 ${BINARIES_DIR}/rootfs.ext4.hash ${BINARIES_DIR}/boot.vfat ${BINARIES_DIR}/boot.vfat.hash ${BINARIES_DIR}/VERSION.json
 exit $?

--- a/board/opentrons/ot2/rootfs-overlay/etc/nginx/nginx.conf
+++ b/board/opentrons/ot2/rootfs-overlay/etc/nginx/nginx.conf
@@ -18,7 +18,7 @@ http {
 
         client_body_in_file_only off;
         client_body_buffer_size  128k;
-        client_max_body_size     200M;
+        client_max_body_size     2M;
 
         access_log /data/nginx-access.log;
 
@@ -38,6 +38,7 @@ http {
             proxy_set_header         X-Host-IP $server_addr;
             proxy_pass               http://127.0.0.1:34000;
             proxy_request_buffering  off;
+            client_max_body_size     0;
         }
     }
 }

--- a/board/opentrons/ot2/rootfs-overlay/usr/lib/systemd/system/avahi-daemon.service.d/run-late.conf
+++ b/board/opentrons/ot2/rootfs-overlay/usr/lib/systemd/system/avahi-daemon.service.d/run-late.conf
@@ -1,0 +1,5 @@
+[unit]
+After=multi-user.target
+
+[install]
+WantedBy=opentrons.target

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -18,5 +18,6 @@ artifacts:
     - output/images/ot2-system.zip
     - output/images/ot2-fullimage.zip
     - output/images/VERSION.json
+    - output/images/ot2-migration.zip
   name: ot2-system
   discard-paths: yes


### PR DESCRIPTION
- Change our image and fstab to exactly match the one balena uses, so we don't have to rewrite the partition table during migration
- Add an ot2-migration.zip artifact, which contains rootfs.ext4, boot.vfat, and hashes for same
- Make sure nginx allows large file transfers
- Bind-mount hostname files from /var so we can set our name
- Run avahi-daemon later than usual during boot so it actually picks up the changed hostname

This is best tested along with the update server migration api (details there) but can be tested in isolation by checking that

- If you modify /var/hostname and restart, the hostname changes on boot
- you see the correct partition table
- You can still upload large files

There is a known issue here with an init-time race condition between avahi-daemon and systemd-hostnamed. Because /etc/hostname is bind-mounted from /var, at early boot systemd sets the hostname to the default in the /etc/hostname file that will later be mounted over. avahi-daemon sees this hostname when it starts. After avahi-daemon runs, systemd-hostnamed starts and changes the hostname, but avahi is still broadcasting with the old one.

The fix for this is documented in https://github.com/Opentrons/opentrons/issues/3319

