### PR TITLE
feat(system): nginx forwards the original host ip to update server

### DIFF
--- a/board/opentrons/ot2/rootfs-overlay/etc/nginx/nginx.conf
+++ b/board/opentrons/ot2/rootfs-overlay/etc/nginx/nginx.conf
@@ -35,6 +35,7 @@ http {
         location /server {
             proxy_http_version       1.1;
             proxy_read_timeout       1h;
+            proxy_set_header         X-Host-IP $server_addr;
             proxy_pass               http://127.0.0.1:34000;
             proxy_request_buffering  off;
         }


### PR DESCRIPTION
This lets the update server discriminate between requests coming from the wifi and the usb to ethernet adapter. Required for https://github.com/Opentrons/opentrons/pull/3339