### PR TITLE
feat(system): configure datadog

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,8 @@ ARG filter_output
 VOLUME /buildroot
 
 RUN apt-get -y update &&\
-  apt-get -y install build-essential wget file cpio python rsync unzip bc libncurses-dev git
+  apt-get -y install build-essential wget file cpio python rsync unzip bc libncurses-dev git curl
+
 
 RUN wget http://crosstool-ng.org/download/crosstool-ng/crosstool-ng-1.23.0.tar.xz &&\
   tar xf ./crosstool-* &&\

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ This fork requires the [opentrons repo](https://github.com/Opentrons/opentrons) 
 
 To build, make sure ``docker`` and ``git`` are installed, and the monorepo is checked out as a neighbor, and run ``./opentrons_build.sh``. This will build the docker container and run a build in it.
 
+The API key for our log aggregator, datadog, can be provided either by specifying it in the ``DATADOG_API_KEY`` env var or by having aws creds available to pull it (and python3 and boto3 installed). If not specified, the build will run and work, but that robot will be unable to upload logs to datadog.
+
 You can build other Buildroot makefile targets using this script by putting them in the last argument. The arguments are split so that the last argument is passed to the makefile and the first arguments are passed to docker. That means if you want to build the targets ``python-opentrons-api`` and ``all`` (``all`` is how you get images out) you would do ``./opentrons-build.sh "python-opentrons-api all"``. If you wanted to run menuconfig, you would run ``./opentrons-build.sh -ti menuconfig``, so docker gave you a terminal and the makefile runs menuconfig
 
 You can control the release type with the ``OT2_BUILD_TYPE`` environment variable. If you set this to ``release``, the system will try and sign the output using a private key in the ``SIGNING_KEY`` environment variable.

--- a/board/opentrons/ot2/post-build.sh
+++ b/board/opentrons/ot2/post-build.sh
@@ -3,9 +3,6 @@
 set -u
 set -e
 
-# Load the out-of-container env to get stuff from codebuild
-export $(cat /buildroot/.env | xargs)
-
 GENIMAGE_TMP="${BUILD_DIR}/genimage.tmp"
 
 # Add a console on tty1
@@ -71,3 +68,13 @@ cp ${BINARIES_DIR}/VERSION.json ${TARGET_DIR}/etc/VERSION.json
 # would be rewritten by aws
 rm -f ${TARGET_DIR}/etc/dropbear
 ln -sf /var/run/dropbear ${TARGET_DIR}/etc/dropbear
+
+
+# Syslog-ng extra setup:
+# - install the datadog api key
+
+echo "@define datadog_api_key \"${DATADOG_API_KEY}\"" > ${TARGET_DIR}/etc/syslog-ng/api_key.conf
+mkdir -p ${TARGET_DIR}/etc/syslog-ng/certs.d/
+rm -rf ${TARGET_DIR}/etc/syslog-ng/certs.d/*
+curl https://docs.datadoghq.com/resources/crt/FULL_intake.logs.datadoghq.com.crt > ${TARGET_DIR}/etc/syslog-ng/certs.d/datadoghq.com.crt
+

--- a/board/opentrons/ot2/post-image.sh
+++ b/board/opentrons/ot2/post-image.sh
@@ -2,9 +2,6 @@
 
 set -e
 
-# Load the out-of-container env to get stuff from codebuild
-export $(cat /buildroot/.env | xargs)
-
 BOARD_DIR="$(dirname $0)"
 BOARD_NAME="$(basename ${BOARD_DIR})"
 GENIMAGE_CFG="${BOARD_DIR}/genimage-${BOARD_NAME}.cfg"

--- a/board/opentrons/ot2/rootfs-overlay/etc/syslog-ng.conf
+++ b/board/opentrons/ot2/rootfs-overlay/etc/syslog-ng.conf
@@ -1,21 +1,35 @@
 @version: 3.10
+@define allow-config-dups 1
+@define datadog_api_key ""
+@include "/etc/syslog-ng/api_key.conf"
 
 source s_journ {
-       systemd-journal(prefix(""));
+  systemd-journal(prefix(""));
 };
 
 source s_int {
-       internal();
+  internal();
 };
 
+template datadog_format {
+  template("`datadog_api_key` <${PRI}>1 ${ISODATE} ${HOST:--} ${PROGRAM:--} ${PID:--} ${MSGID:--} ${SDATA:--} $MSG\n");
+};
+
+destination d_datadog {
+  network("intake.logs.datadoghq.com" port(10516)
+          transport("tls")
+          tls(peer-verify(required-untrusted)
+              ca-dir("/etc/syslog-ng/certs.d"))
+          template(datadog_format));
+};
 
 filter api_logs {
-       in-list("/etc/syslog-ng/opentrons-sources", value("PROGRAM"));
+  in-list("/etc/syslog-ng/opentrons-sources", value("PROGRAM"));
 };
 
 log {
-       source(s_journ);
-       source(s_int);
-       filter(api_logs);
-       #destination(papertrail);
+  source(s_journ);
+  source(s_int);
+  filter(api_logs);
+  destination(d_datadog);
 };

--- a/board/opentrons/ot2/rootfs-overlay/etc/syslog-ng.conf
+++ b/board/opentrons/ot2/rootfs-overlay/etc/syslog-ng.conf
@@ -1,7 +1,6 @@
 @version: 3.10
-@define allow-config-dups 1
-@define datadog_api_key ""
 @include "/etc/syslog-ng/api_key.conf"
+@include "/etc/syslog-ng/level-filter/plugin.conf"
 
 source s_journ {
   systemd-journal(prefix(""));
@@ -27,9 +26,14 @@ filter api_logs {
   in-list("/etc/syslog-ng/opentrons-sources", value("PROGRAM"));
 };
 
+filter f_minlevel {
+  level-filter();
+};
+
 log {
   source(s_journ);
   source(s_int);
   filter(api_logs);
+  filter(f_minlevel);
   destination(d_datadog);
 };

--- a/board/opentrons/ot2/rootfs-overlay/etc/syslog-ng/level-filter/create-level-filter.sh
+++ b/board/opentrons/ot2/rootfs-overlay/etc/syslog-ng/level-filter/create-level-filter.sh
@@ -1,0 +1,14 @@
+LOG_LEVEL_DIR=/var/lib/syslog-ng
+LOG_LEVEL_FILE=${LOG_LEVEL_DIR}/min-level
+
+if [ ! -f ${LOG_LEVEL_FILE} ]
+then
+    mkdir -p /var/lib/syslog-ng
+    echo "debug" > /var/lib/syslog-ng/min-level
+fi
+
+level=$(cat ${LOG_LEVEL_FILE})
+
+# The actual filter statement. This sets the minimum
+# log level to what was in the level file
+echo "level(${level}..emerg);"

--- a/board/opentrons/ot2/rootfs-overlay/etc/syslog-ng/level-filter/plugin.conf
+++ b/board/opentrons/ot2/rootfs-overlay/etc/syslog-ng/level-filter/plugin.conf
@@ -1,0 +1,1 @@
+@module confgen context(filter) name(level-filter) exec("/etc/syslog-ng/level-filter/create-level-filter.sh")

--- a/board/opentrons/ot2/rootfs-overlay/etc/systemd/system/syslog-ng.service.d/establish-state-dir.conf
+++ b/board/opentrons/ot2/rootfs-overlay/etc/systemd/system/syslog-ng.service.d/establish-state-dir.conf
@@ -1,0 +1,2 @@
+[Service]
+StateDirectory=syslog-ng

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -5,6 +5,7 @@ env:
     OT_BUILD_TYPE: dev
   parameter-store:
     SIGNING_KEY: /buildroot-codebuild/signing-key
+    DATADOG_API_KEY: /buildroot-codebuild/datadog-api
 
 phases:
   pre_build:

--- a/get_parameter.py
+++ b/get_parameter.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+import sys
+import argparse
+import boto3
+
+
+def get_parameter(param_name):
+    session = boto3.session.Session(region_name='us-east-2')
+    cli = session.client('ssm')
+    return cli.get_parameter(
+        Name=param_name, WithDecryption=True)['Parameter']['Value']
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Pull a parameter')
+    parser.add_argument('param_name', metavar='PARAM', type=str)
+    parser.add_argument('output', metavar='OUTPUT',
+                        default='-', type=argparse.FileType('w'),
+                        help='Where to write the output (default: stdout)')
+    args = parser.parse_args()
+    try:
+        param = get_parameter(args.param_name)
+    except Exception as e:
+        sys.stderr.write('Failed to get param {0}: {1}\n'.format(args.param_name, repr(e)))
+        param = ''
+    args.output.write(param)


### PR DESCRIPTION
This PR
- Configures syslog-ng to upload to datadog
- Adds a way to modify the minimum log level that will be uploaded

The datadog API key is retrieved from either the environment, or if possible AWS directly. If it cannot be retrieved, log aggregation won't work on the build - but everything else will.

Writing a valid syslog level to /var/lib/syslog-ng/minlevel will make that the minimum level at which logs get to datadog.

Closes https://github.com/Opentrons/opentrons/issues/3421