### PR TITLE
chore(build): Fuse migration and update files

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The repo is built automatically
 - When new commits are pushed to a branch of the monorepo that has a matching branch in this repo (non-release)
 - When a tag is pushed to the monorepo (release), using the latest github release in this repo
 
-When builds complete, they are uploaded to an s3 bucket prefixed by the codebuild build id (see the buildspec file). If the build was a release build, the manifest `releases.json` in the root of the bucket is updated so that the key path `/production/{monorepo-version}` contains a dict mapping `system'` to the path of the update file zip, `'fullImage'` to the path of the provisioning zip,  `'migration'` to the path of the migration zip, and `'version'` to the path of the version file. For instance, the manifest might look like
+When builds complete, they are uploaded to an s3 bucket prefixed by the codebuild build id (see the buildspec file). If the build was a release build, the manifest `releases.json` in the root of the bucket is updated so that the key path `/production/{monorepo-version}` contains a dict mapping `system'` to the path of the update file zip, `'fullImage'` to the path of the provisioning zip, and `'version'` to the path of the version file. For instance, the manifest might look like
 
 ```json
 {
@@ -48,8 +48,7 @@ When builds complete, they are uploaded to an s3 bucket prefixed by the codebuil
     "3.8.3": {
       "fullImage": "https://opentrons-buildroot-ci.s3.amazonaws.com/ebc9f421-04db-4ec8-87bd-f990c69bbd80/opentrons-buildroot/ot2-fullimage.zip",
       "system": "https://opentrons-buildroot-ci.s3.amazonaws.com/ebc9f421-04db-4ec8-87bd-f990c69bbd80/opentrons-buildroot/ot2-system.zip",
-      "version": "https://opentrons-buildroot-ci.s3.amazonaws.com/ebc9f421-04db-4ec8-87bd-f990c69bbd80/opentrons-buildroot/VERSION.json",
-      "migration": "https://opentrons-buildroot-ci.s3.amazonaws.com/ebc9f421-04db-4ec8-87bd-f990c69bbd80/opentrons-buildroot/ot2-migration.zip"
+      "version": "https://opentrons-buildroot-ci.s3.amazonaws.com/ebc9f421-04db-4ec8-87bd-f990c69bbd80/opentrons-buildroot/VERSION.json"
     }
   }
 }

--- a/board/opentrons/ot2/post-image.sh
+++ b/board/opentrons/ot2/post-image.sh
@@ -80,14 +80,16 @@ shasum -a 256 ${BINARIES_DIR}/rootfs.ext4 | grep -oh "^.\+ " > ${BINARIES_DIR}/r
 echo "Generating hash for boot.vfat..."
 shasum -a 256 ${BINARIES_DIR}/boot.vfat | grep -oh "^.\+ " > ${BINARIES_DIR}/boot.vfat.hash
 
+boot_files="${BINARIES_DIR}/boot.vfat ${BINARIES_DIR}/boot.vfat.hash"
+
 if [ ${OT_BUILD_TYPE} = "release" ]; then
     echo "Build type is RELEASE"
     echo "Signing rootfs hash"
     openssl dgst -sha256 -sign .signing-key -out ${BINARIES_DIR}/rootfs.ext4.hash.sig ${BINARIES_DIR}/rootfs.ext4.hash
-    system_files="${BINARIES_DIR}/rootfs.ext4 ${BINARIES_DIR}/rootfs.ext4.hash ${BINARIES_DIR}/VERSION.json ${BINARIES_DIR}/rootfs.ext4.hash.sig"
+    system_files="${BINARIES_DIR}/rootfs.ext4 ${BINARIES_DIR}/rootfs.ext4.hash ${BINARIES_DIR}/VERSION.json ${BINARIES_DIR}/rootfs.ext4.hash.sig ${boot_files}"
 else
     echo "Build type is NOT RELEASE"
-    system_files="${BINARIES_DIR}/rootfs.ext4 ${BINARIES_DIR}/rootfs.ext4.hash ${BINARIES_DIR}/VERSION.json"
+    system_files="${BINARIES_DIR}/rootfs.ext4 ${BINARIES_DIR}/rootfs.ext4.hash ${BINARIES_DIR}/VERSION.json ${boot_files}"
 fi
 
 echo "Zipping system image..."
@@ -97,8 +99,4 @@ zip -j ${BINARIES_DIR}/ot2-system.zip ${system_files} ${BINARIES_DIR}/VERSION.js
 echo "Zipping full sd card image..."
 rm -f ${BINARIES_DIR}/ot2-fullimage.zip
 zip -j ${BINARIES_DIR}/ot2-fullimage.zip ${BINARIES_DIR}/sdcard.img ${BINARIES_DIR}/VERSION.json
-
-echo "Zipping migration image..."
-rm -f ${BINARIES_DIR}/ot2-migration.zip
-zip -j ${BINARIES_DIR}/ot2-migration.zip ${BINARIES_DIR}/rootfs.ext4 ${BINARIES_DIR}/rootfs.ext4.hash ${BINARIES_DIR}/boot.vfat ${BINARIES_DIR}/boot.vfat.hash ${BINARIES_DIR}/VERSION.json
 exit $?

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -19,6 +19,5 @@ artifacts:
     - output/images/ot2-system.zip
     - output/images/ot2-fullimage.zip
     - output/images/VERSION.json
-    - output/images/ot2-migration.zip
   name: ot2-system
   discard-paths: yes


### PR DESCRIPTION
Having separate migration and update files means users have to know the
difference when picking one to upload to a robot. The only difference between
them is the presence or absence of a boot partition and hash, which are both
very small when zipped.

Remove the concept of a migration image and add the boot partition
unconditionally to the system update file.

Closes https://github.com/Opentrons/opentrons/issues/3559