### PR TITLE
chore(build): Put release notes from monorepo in artifacts

### DIFF
--- a/board/opentrons/ot2/post-image.sh
+++ b/board/opentrons/ot2/post-image.sh
@@ -94,9 +94,9 @@ fi
 
 echo "Zipping system image..."
 rm -f ${BINARIES_DIR}/ot2-system.zip
-zip -j ${BINARIES_DIR}/ot2-system.zip ${system_files} ${BINARIES_DIR}/VERSION.json
+zip -j ${BINARIES_DIR}/ot2-system.zip ${system_files} ${BINARIES_DIR}/VERSION.json ${BINARIES_DIR}/release-notes.md
 
 echo "Zipping full sd card image..."
 rm -f ${BINARIES_DIR}/ot2-fullimage.zip
-zip -j ${BINARIES_DIR}/ot2-fullimage.zip ${BINARIES_DIR}/sdcard.img ${BINARIES_DIR}/VERSION.json
+zip -j ${BINARIES_DIR}/ot2-fullimage.zip ${BINARIES_DIR}/sdcard.img ${BINARIES_DIR}/VERSION.json ${BINARIES_DIR}/release-notes.md
 exit $?

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -19,5 +19,6 @@ artifacts:
     - output/images/ot2-system.zip
     - output/images/ot2-fullimage.zip
     - output/images/VERSION.json
+    - output/images/release-notes.md
   name: ot2-system
   discard-paths: yes


### PR DESCRIPTION
They are installed by the monorepo makefile and included in the upload to s3 and
the update zips.