### PR TITLE
fix(system): prevent camera from becoming alsa default device

### DIFF
--- a/board/opentrons/ot2/rootfs-overlay/etc/modprobe.d/alsa-base.conf
+++ b/board/opentrons/ot2/rootfs-overlay/etc/modprobe.d/alsa-base.conf
@@ -1,0 +1,2 @@
+# prevent the installed usb camera from becoming alsa default device
+options snd-usb-audio index=-2

--- a/opentrons-build.sh
+++ b/opentrons-build.sh
@@ -51,6 +51,7 @@ docker build ${filter_arg} -t ${imgname} .
 # Save codebuild-relevant env vars to get them inside docker
 env | grep 'CODEBUILD\|AWS\|DATADOG' >.env
 echo "OT_BUILD_TYPE=${OT_BUILD_TYPE-dev}">>.env
+echo "FORCE_UNSAFE_CONFIGURE=1">>.env
 echo "${SIGNING_KEY}" > .signing-key
 
 case $# in


### PR DESCRIPTION
Sometimes when the device boots, the usb camera's audio interface will get
enumerated before the bcm sound hardware from the pi. It's also only a mic. That
means that when you try to play sound, alsa can't take the device (since it's
not an output driver) and fail. We could configure alsa to use index 1 by
default, but maybe the initialization will change or the camera won't be plugged
in. This change just tells alsa to never use a usb audio device as the default,
which should leave the platform hardware the only thing to use.

Test by installing or by making this change (creating /etc/modprobe.d and putting this file in it) and rebooting. Then run `mpg123 /etc/audio/speaker-test.mp3` and hear it work. You should also be able to `cat /proc/asound/cards` and note that card 0 is `bcm2835 ALSA`.