### PR TITLE
chore(build): add caching in buildspec

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -22,3 +22,7 @@ artifacts:
     - output/images/release-notes.md
   name: ot2-system
   discard-paths: yes
+
+cache:
+  paths:
+    - dl/


### PR DESCRIPTION
We have problems with rate limiting from upstream mirrors, so caching the
download directory should prevent this (and speed up builds).