### PR TITLE
fix(system): fix pip config to allow installs again

### DIFF
--- a/board/opentrons/ot2/rootfs-overlay/etc/pip/pip.conf
+++ b/board/opentrons/ot2/rootfs-overlay/etc/pip/pip.conf
@@ -1,2 +1,2 @@
-[global]
+[install]
 root = /var/user-packages


### PR DESCRIPTION
The root option is under the install scope not the global scope. Now you can
install packages (that don't require compilation) again.

## Testing

Install this and try to install some pure python package like [cxio](https://pypi.org/project/cxio/) which was the first thing I saw browsing python.

Alternately, you can edit your /etc/pip/pip.conf and make the same change.