### PR TITLE
fix(system): add thermocycler udev rules

### DIFF
--- a/board/opentrons/ot2/rootfs-overlay/etc/udev/rules.d/95-opentrons-modules.rules
+++ b/board/opentrons/ot2/rootfs-overlay/etc/udev/rules.d/95-opentrons-modules.rules
@@ -1,3 +1,7 @@
 KERNEL=="ttyACM[0-9]*", SUBSYSTEMS=="usb", ATTRS{idProduct}=="ee93", ATTRS{idVendor}=="04d8", SYMLINK+="modules/tty%n_tempdeck"
 KERNEL=="ttyACM[0-9]*", SUBSYSTEMS=="usb", ATTRS{idProduct}=="ee90", ATTRS{idVendor}=="04d8", SYMLINK+="modules/tty%n_magdeck"
 KERNEL=="ttyACM[0-9]*", SUBSYSTEMS=="usb", ATTRS{idProduct}=="ee5a", ATTRS{idVendor}=="04d8", SYMLINK+="modules/tty%n_bootloader"
+KERNEL=="ttyACM[0-9]*", SUBSYSTEMS=="usb", ATTRS{idProduct}=="ed8c", ATTRS{idVendor}=="04d8", SYMLINK+="modules/tty%n_thermocycler"
+KERNEL=="ttyACM[0-9]*", SUBSYSTEMS=="usb", ATTRS{idProduct}=="ed12", ATTRS{idVendor}=="04d8", SYMLINK+="modules/tty%n_thermocycler_bootloader"
+# adafruit feather m0 board for dev:
+KERNEL=="ttyACM[0-9]*", SUBSYSTEMS=="usb", ATTRS{idProduct}=="800b", ATTRS{idVendor}=="239a", SYMLINK+="modules/tty%n_thermocycler"


### PR DESCRIPTION
Add udev rules to allow thermocycler  module and bootloader to be recognized.