### PR TITLE
fix(system): fix jupyter trash and migrate notebooks

### DIFF
--- a/board/opentrons/ot2/rootfs-overlay/etc/jupyter/jupyter_notebook_config.py
+++ b/board/opentrons/ot2/rootfs-overlay/etc/jupyter/jupyter_notebook_config.py
@@ -631,7 +631,7 @@ c.NotebookApp.token = ''
 ## If True (default), deleting files will send them to the platform's
 #  trash/recycle bin, where they can be recovered. If False, deleting files
 #  really deletes them.
-c.FileContentsManager.delete_to_trash = True
+c.FileContentsManager.delete_to_trash = False
 
 ## Python callable or importstring thereof
 #

--- a/board/opentrons/ot2/rootfs-overlay/etc/jupyter/jupyter_notebook_config.py
+++ b/board/opentrons/ot2/rootfs-overlay/etc/jupyter/jupyter_notebook_config.py
@@ -631,7 +631,7 @@ c.NotebookApp.token = ''
 ## If True (default), deleting files will send them to the platform's
 #  trash/recycle bin, where they can be recovered. If False, deleting files
 #  really deletes them.
-#c.FileContentsManager.delete_to_trash = True
+c.FileContentsManager.delete_to_trash = True
 
 ## Python callable or importstring thereof
 #

--- a/board/opentrons/ot2/rootfs-overlay/etc/systemd/system/jupyter-notebook.service
+++ b/board/opentrons/ot2/rootfs-overlay/etc/systemd/system/jupyter-notebook.service
@@ -8,7 +8,7 @@ PIDFile=%t/jupyter/jupyter.pid
 SupplementaryGroups=dialout
 StateDirectory=jupyter jupyter/notebooks jupyter/data jupyter/config ipython
 RuntimeDirectory=jupyter
-Environment=JUPYTER_RUNTIME_DIR=%t/jupyter JUPYTER_CONFIG_DIR=%S/jupyter/config JUPYTER_DATA_DIR=%S/jupyter/data IPYTHONDIR=%S/ipython OT_SMOOTHIE_ID=AMA RUNNING_ON_PI=true
+Environment=JUPYTER_RUNTIME_DIR=%t/jupyter JUPYTER_CONFIG_DIR=%S/jupyter/config JUPYTER_DATA_DIR=%S/jupyter/data IPYTHONDIR=%S/ipython JUPYTER_NOTEBOOK_DIR=%S/jupyter/notebooks OT_SMOOTHIE_ID=AMA RUNNING_ON_PI=true
 
 [Install]
 WantedBy=opentrons.target

--- a/board/opentrons/ot2/rootfs-overlay/etc/systemd/system/jupyter-notebook.service.d/migrate-notebooks.conf
+++ b/board/opentrons/ot2/rootfs-overlay/etc/systemd/system/jupyter-notebook.service.d/migrate-notebooks.conf
@@ -1,0 +1,2 @@
+[Service]
+ExecStartPre=/bin/sh /etc/systemd/system/jupyter-notebook.service.d/migrate-notebooks.sh

--- a/board/opentrons/ot2/rootfs-overlay/etc/systemd/system/jupyter-notebook.service.d/migrate-notebooks.sh
+++ b/board/opentrons/ot2/rootfs-overlay/etc/systemd/system/jupyter-notebook.service.d/migrate-notebooks.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+
+# migrate-nobteooks.sh: move jupyter notebooks created before the migration to
+# buildroot into the directory jupyter uses for its notebooks on buildroot
+
+# if this robot doesn't have /var/resin-data, then it wasn't migrated from
+# balena, and we don't have to check for old notebooks
+if [ ! -d /var/resin-data ] ; then
+    exit 0
+fi
+
+NOTEBOOK_DIR="${STATE_DIRECTORY}/jupyter/notebooks"
+
+# get any notebooks saved in the old notebook directories. we have to use find
+# -name here because this is the old balena /data root, which invisibly to the
+# old containers actually had the application id in the path; we lost that id
+# after migration, so we have to search all of them.
+notebooks=$(find /var/resin-data -name *.ipynb | grep -v '.*ipynb_checkpoints.*')
+
+for nb in $notebooks; do
+    _filename=$(basename "$nb")
+    _basename=$(basename "$_filename" ".ipynb")
+    if [ -e "${NOTEBOOK_DIR}/${_filename}" ]; then
+        echo "${NOTEBOOK_DIR}/${_filename} exists"
+        _suffix=1
+        while [ -e "${NOTEBOOK_DIR}/${_basename}-${_suffix}.ipynb" ]; do
+            echo "${NOTEBOOK_DIR}/${_basename}-${_suffix}.ipynb exists"
+            ++_suffix
+        done;
+        _newname="${_basename}-${_suffix}.ipynb"
+        echo "${NOTEBOOK_DIR}/${_newname} OK"
+    else
+        _newname=$_filename
+    fi
+    echo "${nb} -> ${NOTEBOOK_DIR}/${_newname}"
+    mv "${nb}" "${NOTEBOOK_DIR}/${_newname}"
+done
+


### PR DESCRIPTION
Fix two issues with jupyter on buildroot. https://github.com/Opentrons/opentrons/issues/4004 arises because of bind mounting something into /root which then is the xdg home directory and used for the trash, but it's a different filesystem, so everything breaks; and https://github.com/Opentrons/opentrons/issues/4002 arises because we plumb forgot to migrate jupyter notebooks.

## Testing
- Plop some jupyter notebooks (*.ipynb) in `/var/resin-data/1058245/user_storage/opentrons_data/jupyter` (that was the old opentrons-customers application id), then restart the robot or the jupyter service and check that they appear afterwards
- Delete a file from the jupyter notebook gui and see that it doesn't raise an exception.