### PR TITLE
fix(system): networkmanager.conf: disable auto default for only eth0

### DIFF
--- a/board/opentrons/ot2/rootfs-overlay/etc/NetworkManager/conf.d/disable-autoeth0.conf
+++ b/board/opentrons/ot2/rootfs-overlay/etc/NetworkManager/conf.d/disable-autoeth0.conf
@@ -1,2 +1,2 @@
 [main]
-no-auto-default=*
+no-auto-default=eth0


### PR DESCRIPTION
We need to disable auto defaults for eth0 so we can do our special dhcp with
linklocal fallback, but disabling it for _everything_ means that you can't plug
in a usb/ethernet adapter, which sometimes people do so they can connect to a
wired network.

Closes https://github.com/Opentrons/opentrons/issues/2836