### PR TITLE
fix(system): Force journald storage to /var/

### DIFF
--- a/board/opentrons/ot2/rootfs-overlay/etc/systemd/journald.conf.d/log_storage.conf
+++ b/board/opentrons/ot2/rootfs-overlay/etc/systemd/journald.conf.d/log_storage.conf
@@ -1,0 +1,2 @@
+[Journal]
+Storage=persistent


### PR DESCRIPTION
This makes us store more data and actually store it persistently in the filesystem.

## Testing

You can make this change on a robot without waiting for a build, but testing needs to consist of

- Apply this change and restart the robot and make sure it works, because we have some early-boot mount shenanigans that may cause journald to think /var isn't mounted and usable
- Check that the default of 10% of the filesystem is a sane default for the max size of log files