### PR TITLE
fix(system): ensure robot button light on after setup

### DIFF
--- a/board/opentrons/ot2/rootfs-overlay/usr/bin/ot-blinkenlights
+++ b/board/opentrons/ot2/rootfs-overlay/usr/bin/ot-blinkenlights
@@ -4,6 +4,8 @@ import importlib
 import os
 import sys
 import time
+import atexit
+import signal
 
 ot = importlib.find_loader('opentrons')
 ot_root = os.path.dirname(ot.get_filename())
@@ -26,6 +28,11 @@ gpio.set_low(gpio.OUTPUT_PINS['RESET'])
 time.sleep(0.25)
 gpio.set_high(gpio.OUTPUT_PINS['RESET'])
 time.sleep(0.25)
+
+def handleTerm(signal_number, frame):
+    raise KeyboardInterrupt
+signal.signal(signal.SIGTERM, handleTerm)
+atexit.register(lambda: gpio.set_button_light(blue=True))
 
 # Start blinking button blue
 while True:

--- a/board/opentrons/ot2/rootfs-overlay/usr/bin/ot-blinkenlights
+++ b/board/opentrons/ot2/rootfs-overlay/usr/bin/ot-blinkenlights
@@ -30,6 +30,7 @@ time.sleep(0.25)
 
 def handleSignal(signal_number, frame):
     gpio.set_button_light(blue=True)
+    os._exit()
 
 signal.signal(signal.SIGTERM, handleSignal)
 signal.signal(signal.SIGINT, handleSignal)

--- a/board/opentrons/ot2/rootfs-overlay/usr/bin/ot-blinkenlights
+++ b/board/opentrons/ot2/rootfs-overlay/usr/bin/ot-blinkenlights
@@ -4,11 +4,7 @@ import importlib
 import os
 import sys
 import time
-import atexit
-<<<<<<< HEAD
 import signal
-=======
->>>>>>> afbcae193e3824c08cc8c5d5fc631e2424e5da27
 
 ot = importlib.find_loader('opentrons')
 ot_root = os.path.dirname(ot.get_filename())
@@ -32,13 +28,11 @@ time.sleep(0.25)
 gpio.set_high(gpio.OUTPUT_PINS['RESET'])
 time.sleep(0.25)
 
-<<<<<<< HEAD
-def handleTerm(signal_number, frame):
-    raise KeyboardInterrupt
-signal.signal(signal.SIGTERM, handleTerm)
-=======
->>>>>>> afbcae193e3824c08cc8c5d5fc631e2424e5da27
-atexit.register(lambda: gpio.set_button_light(blue=True))
+def handleSignal(signal_number, frame):
+    gpio.set_button_light(blue=True)
+
+signal.signal(signal.SIGTERM, handleSignal)
+signal.signal(signal.SIGINT, handleSignal)
 
 # Start blinking button blue
 while True:

--- a/board/opentrons/ot2/rootfs-overlay/usr/bin/ot-blinkenlights
+++ b/board/opentrons/ot2/rootfs-overlay/usr/bin/ot-blinkenlights
@@ -30,7 +30,7 @@ time.sleep(0.25)
 
 def handleSignal(signal_number, frame):
     gpio.set_button_light(blue=True)
-    os._exit()
+    os._exit(0)
 
 signal.signal(signal.SIGTERM, handleSignal)
 signal.signal(signal.SIGINT, handleSignal)

--- a/board/opentrons/ot2/rootfs-overlay/usr/bin/ot-blinkenlights
+++ b/board/opentrons/ot2/rootfs-overlay/usr/bin/ot-blinkenlights
@@ -4,6 +4,7 @@ import importlib
 import os
 import sys
 import time
+import atexit
 
 ot = importlib.find_loader('opentrons')
 ot_root = os.path.dirname(ot.get_filename())
@@ -26,6 +27,8 @@ gpio.set_low(gpio.OUTPUT_PINS['RESET'])
 time.sleep(0.25)
 gpio.set_high(gpio.OUTPUT_PINS['RESET'])
 time.sleep(0.25)
+
+atexit.register(lambda: gpio.set_button_light(blue=True))
 
 # Start blinking button blue
 while True:


### PR DESCRIPTION
Ensure that button light is set to blue when gpio setup is stopped via system control.