### PR TITLE
fix(system): make mounts public, add tc bootloader symlink

### DIFF
--- a/board/opentrons/ot2/rootfs-overlay/etc/systemd/system/systemd-udevd.service.d/public-mounts.conf
+++ b/board/opentrons/ot2/rootfs-overlay/etc/systemd/system/systemd-udevd.service.d/public-mounts.conf
@@ -1,0 +1,2 @@
+[Service]
+PrivateMounts=no

--- a/board/opentrons/ot2/rootfs-overlay/etc/usbmount/mount.d/01_create_tc_bootloader_symlink
+++ b/board/opentrons/ot2/rootfs-overlay/etc/usbmount/mount.d/01_create_tc_bootloader_symlink
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+test $ID_MODEL_ID = "ed12" && test $ID_VENDOR_ID = "04d8" || exit 0
+
+name="thermocycler_bootloader_volume"
+
+# If the symlink does not yet exist, create it.
+test -e "/dev/modules/$name" || ln -sf "$UM_MOUNTPOINT" "/dev/modules/$name"
+
+exit 0

--- a/board/opentrons/ot2/rootfs-overlay/etc/usbmount/umount.d/01_remove_tc_bootloader_symlink
+++ b/board/opentrons/ot2/rootfs-overlay/etc/usbmount/umount.d/01_remove_tc_bootloader_symlink
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+env > /var/env_test
+
+test $ID_MODEL_ID = "ed12" && test $ID_VENDOR_ID = "04d8" || exit 0
+
+rm -f "/dev/modules/thermocycler_bootloader_volume"
+
+exit 0


### PR DESCRIPTION
Overwrite udevd default for private mounts, allowing for module firmware updates where bootloader mounts as usb mass storage device. 