### PR TITLE
fix(system): opentrons/ot2: make wired connections use static macs

### DIFF
--- a/board/opentrons/ot2/rootfs-overlay/usr/share/default-connections/wired
+++ b/board/opentrons/ot2/rootfs-overlay/usr/share/default-connections/wired
@@ -15,6 +15,7 @@ interface-name=eth0
 permissions=
 
 [ethernet]
+cloned-mac-address=permanent
 mac-address-blacklist=
 
 [ipv4]

--- a/board/opentrons/ot2/rootfs-overlay/usr/share/default-connections/wired-linklocal
+++ b/board/opentrons/ot2/rootfs-overlay/usr/share/default-connections/wired-linklocal
@@ -13,6 +13,7 @@ interface-name=eth0
 permissions=
 
 [ethernet]
+cloned-mac-address=permanent
 mac-address-blacklist=
 
 [ipv4]


### PR DESCRIPTION
Testing:

- Install the build (or copy the changes over)
- Restart the robot
- Dump the mac addr
- Restart the robot
- Dump the mac addr 
- SHould be the same both times