### PR TITLE
fix: board/opentrons/ot2: strip newlines in syslog upstreaming

### DIFF
--- a/board/opentrons/ot2/rootfs-overlay/etc/syslog-ng.conf
+++ b/board/opentrons/ot2/rootfs-overlay/etc/syslog-ng.conf
@@ -30,10 +30,15 @@ filter f_minlevel {
   level-filter();
 };
 
+rewrite r_nonewlines {
+  subst("\n", ";", value("MESSAGE") flags("global"));
+};
+
 log {
   source(s_journ);
   source(s_int);
   filter(api_logs);
   filter(f_minlevel);
+  rewrite(r_nonewlines);
   destination(d_datadog);
 };


### PR DESCRIPTION
The syslog daemon is configured to send data to Datadog via tcp, and it doesn't
handle newlines in messages (for instance, in python stack traces) very well.
Add a rewrite rule for s/\n/; to get rid of them.

Closes https://github.com/Opentrons/opentrons/issues/4380

## Testing:

Install this (or modify the file manually) on a robot and induce some python errors. Instead of showing up on Datadog with only the first line of the stack trace, they should now appear with the full stack trace with newlines replaced by semicolons.