### PR TITLE
Add top level module symlinks

### DIFF
--- a/board/opentrons/ot2/rootfs-overlay/etc/udev/rules.d/95-opentrons-modules.rules
+++ b/board/opentrons/ot2/rootfs-overlay/etc/udev/rules.d/95-opentrons-modules.rules
@@ -1,7 +1,7 @@
-KERNEL=="ttyACM[0-9]*", SUBSYSTEMS=="usb", ATTRS{idProduct}=="ee93", ATTRS{idVendor}=="04d8", SYMLINK+="modules/tty%n_tempdeck ot_module_tempdeck%n"
-KERNEL=="ttyACM[0-9]*", SUBSYSTEMS=="usb", ATTRS{idProduct}=="ee90", ATTRS{idVendor}=="04d8", SYMLINK+="modules/tty%n_magdeck ot_module_magdeck%n"
-KERNEL=="ttyACM[0-9]*", SUBSYSTEMS=="usb", ATTRS{idProduct}=="ee5a", ATTRS{idVendor}=="04d8", SYMLINK+="modules/tty%n_bootloader ot_module_bootloader%n"
-KERNEL=="ttyACM[0-9]*", SUBSYSTEMS=="usb", ATTRS{idProduct}=="ed8c", ATTRS{idVendor}=="04d8", SYMLINK+="modules/tty%n_thermocycler ot_module_thermocycler%n"
-KERNEL=="ttyACM[0-9]*", SUBSYSTEMS=="usb", ATTRS{idProduct}=="ed12", ATTRS{idVendor}=="04d8", SYMLINK+="modules/tty%n_thermocycler_bootloader ot_module_thermocycler_bootloader%n"
+KERNEL=="ttyACM[0-9]*", SUBSYSTEMS=="usb", ATTRS{idProduct}=="ee93", ATTRS{idVendor}=="04d8", SYMLINK+="ot_module_tempdeck%n"
+KERNEL=="ttyACM[0-9]*", SUBSYSTEMS=="usb", ATTRS{idProduct}=="ee90", ATTRS{idVendor}=="04d8", SYMLINK+="ot_module_magdeck%n"
+KERNEL=="ttyACM[0-9]*", SUBSYSTEMS=="usb", ATTRS{idProduct}=="ee5a", ATTRS{idVendor}=="04d8", SYMLINK+="ot_module_avrdude_bootloader%n"
+KERNEL=="ttyACM[0-9]*", SUBSYSTEMS=="usb", ATTRS{idProduct}=="ed8c", ATTRS{idVendor}=="04d8", SYMLINK+="ot_module_thermocycler%n"
+KERNEL=="ttyACM[0-9]*", SUBSYSTEMS=="usb", ATTRS{idProduct}=="ed12", ATTRS{idVendor}=="04d8", SYMLINK+="ot_module_samba_bootloader%n"
 # adafruit feather m0 board for dev:
-KERNEL=="ttyACM[0-9]*", SUBSYSTEMS=="usb", ATTRS{idProduct}=="800b", ATTRS{idVendor}=="239a", SYMLINK+="modules/tty%n_thermocycler ot_module_thermocycler%n"
+KERNEL=="ttyACM[0-9]*", SUBSYSTEMS=="usb", ATTRS{idProduct}=="800b", ATTRS{idVendor}=="239a", SYMLINK+="ot_module_thermocycler%n"

--- a/board/opentrons/ot2/rootfs-overlay/etc/udev/rules.d/95-opentrons-modules.rules
+++ b/board/opentrons/ot2/rootfs-overlay/etc/udev/rules.d/95-opentrons-modules.rules
@@ -1,7 +1,7 @@
-KERNEL=="ttyACM[0-9]*", SUBSYSTEMS=="usb", ATTRS{idProduct}=="ee93", ATTRS{idVendor}=="04d8", SYMLINK+="modules/tty%n_tempdeck"
-KERNEL=="ttyACM[0-9]*", SUBSYSTEMS=="usb", ATTRS{idProduct}=="ee90", ATTRS{idVendor}=="04d8", SYMLINK+="modules/tty%n_magdeck"
-KERNEL=="ttyACM[0-9]*", SUBSYSTEMS=="usb", ATTRS{idProduct}=="ee5a", ATTRS{idVendor}=="04d8", SYMLINK+="modules/tty%n_bootloader"
-KERNEL=="ttyACM[0-9]*", SUBSYSTEMS=="usb", ATTRS{idProduct}=="ed8c", ATTRS{idVendor}=="04d8", SYMLINK+="modules/tty%n_thermocycler"
-KERNEL=="ttyACM[0-9]*", SUBSYSTEMS=="usb", ATTRS{idProduct}=="ed12", ATTRS{idVendor}=="04d8", SYMLINK+="modules/tty%n_thermocycler_bootloader"
+KERNEL=="ttyACM[0-9]*", SUBSYSTEMS=="usb", ATTRS{idProduct}=="ee93", ATTRS{idVendor}=="04d8", SYMLINK+="modules/tty%n_tempdeck ot_module_tempdeck%n"
+KERNEL=="ttyACM[0-9]*", SUBSYSTEMS=="usb", ATTRS{idProduct}=="ee90", ATTRS{idVendor}=="04d8", SYMLINK+="modules/tty%n_magdeck ot_module_magdeck%n"
+KERNEL=="ttyACM[0-9]*", SUBSYSTEMS=="usb", ATTRS{idProduct}=="ee5a", ATTRS{idVendor}=="04d8", SYMLINK+="modules/tty%n_bootloader ot_module_bootloader%n"
+KERNEL=="ttyACM[0-9]*", SUBSYSTEMS=="usb", ATTRS{idProduct}=="ed8c", ATTRS{idVendor}=="04d8", SYMLINK+="modules/tty%n_thermocycler ot_module_thermocycler%n"
+KERNEL=="ttyACM[0-9]*", SUBSYSTEMS=="usb", ATTRS{idProduct}=="ed12", ATTRS{idVendor}=="04d8", SYMLINK+="modules/tty%n_thermocycler_bootloader ot_module_thermocycler_bootloader%n"
 # adafruit feather m0 board for dev:
-KERNEL=="ttyACM[0-9]*", SUBSYSTEMS=="usb", ATTRS{idProduct}=="800b", ATTRS{idVendor}=="239a", SYMLINK+="modules/tty%n_thermocycler"
+KERNEL=="ttyACM[0-9]*", SUBSYSTEMS=="usb", ATTRS{idProduct}=="800b", ATTRS{idVendor}=="239a", SYMLINK+="modules/tty%n_thermocycler ot_module_thermocycler%n"


### PR DESCRIPTION
This will be accompanied by a mono-repo PR that will deprecate usage of /dev/modules/ in favor of /dev/ot_module_* 

