### PR TITLE
chore: refactoring to move start up sequence to opentrons API 

### DIFF
--- a/board/opentrons/ot2/rootfs-overlay/usr/bin/ot-blinkenlights
+++ b/board/opentrons/ot2/rootfs-overlay/usr/bin/ot-blinkenlights
@@ -14,19 +14,7 @@ sys.path.insert(0, gpio_path)
 
 import gpio
 
-gpio.initialize()
-
-# audio-enable pin can stay HIGH always, unless there is noise coming
-# from the amplifier, then we can set to LOW to disable the amplifier
-gpio.set_high(gpio.OUTPUT_PINS['AUDIO_ENABLE'])
-
-# smoothieware programming pins, must be in a known state (HIGH)
-gpio.set_high(gpio.OUTPUT_PINS['HALT'])
-gpio.set_high(gpio.OUTPUT_PINS['ISP'])
-gpio.set_low(gpio.OUTPUT_PINS['RESET'])
-time.sleep(0.25)
-gpio.set_high(gpio.OUTPUT_PINS['RESET'])
-time.sleep(0.25)
+gpio.robot_startup_sequence()
 
 def handleSignal(signal_number, frame):
     gpio.set_button_light(blue=True)


### PR DESCRIPTION
Complement to https://github.com/Opentrons/opentrons/pull/4416 to be merged after that. Breaking change without that PR.

A number of pins need to be set at power-on before the robot can work correctly. Previously some of these were defined only in the ot-blinkenlights script in the buildroot repo. This was confusing to newcomers: in some sense it was the only logic needed for the robot to pipette not to be found in the opentrons repo. These PRs places that logic in a new function, robot_startup_sequence in gpio which is then invoked from ot-blinkenlights.