### PR TITLE
board/opentrons/ot2: always sign builds if key is available

### DIFF
--- a/board/opentrons/ot2/post-image.sh
+++ b/board/opentrons/ot2/post-image.sh
@@ -84,11 +84,16 @@ boot_files="${BINARIES_DIR}/boot.vfat ${BINARIES_DIR}/boot.vfat.hash"
 
 if [ ${OT_BUILD_TYPE} = "release" ]; then
     echo "Build type is RELEASE"
+else
+    echo "Build type is NOT RELEASE"
+fi
+
+if [ -e .signing-key ]; then
     echo "Signing rootfs hash"
     openssl dgst -sha256 -sign .signing-key -out ${BINARIES_DIR}/rootfs.ext4.hash.sig ${BINARIES_DIR}/rootfs.ext4.hash
     system_files="${BINARIES_DIR}/rootfs.ext4 ${BINARIES_DIR}/rootfs.ext4.hash ${BINARIES_DIR}/VERSION.json ${BINARIES_DIR}/rootfs.ext4.hash.sig ${boot_files}"
 else
-    echo "Build type is NOT RELEASE"
+    echo "signing key unavailable, build will not be signed"
     system_files="${BINARIES_DIR}/rootfs.ext4 ${BINARIES_DIR}/rootfs.ext4.hash ${BINARIES_DIR}/VERSION.json ${boot_files}"
 fi
 


### PR DESCRIPTION
We have only been signing builds if the build is a release (so, not most edge
builds). However, it's hard to go from a signed build to an unsigned build - it
involves editing files on the filesystem - and signing the builds doesn't
actually take that long, so let's just do it whenever the signing key is
available.

You can test this PR by installing a release build on your robot, and then installing this: https://opentrons-buildroot-ci.s3.amazonaws.com/29dd9ba2-e7a5-4965-9025-0c7782fbd829/opentrons-buildroot/ot2-system.zip 

It should install cleanly without complaining about missing `rootfs.hash.sig`.
