### PR TITLE
board/opentrons/ot2: only remove signing cert if build is unsigned

### DIFF
--- a/board/opentrons/ot2/post-build.sh
+++ b/board/opentrons/ot2/post-build.sh
@@ -39,8 +39,6 @@ if [ ${OT_BUILD_TYPE} != "release" ]; then
     echo "Build type is NOT RELEASE, adding default ssh key and removing signing"
     # write common pubkey to authorized keys
     cat ${TARGET_DIR}/var/home/.ssh/robot_key.pub > ${TARGET_DIR}/var/home/.ssh/authorized_keys
-    # remove code signing cert (allows unsigned updates)
-    rm ${TARGET_DIR}/etc/opentrons-robot-signing-key.crt
     deployment_to_write="development"
 
 else
@@ -48,6 +46,11 @@ else
     deployment_to_write="production"
 fi
 
+if [ ! -e .signing-key ]; then
+    echo "No signing key present, removing cert"
+    # remove code signing cert (allows unsigned updates)
+    rm ${TARGET_DIR}/etc/opentrons-robot-signing-key.crt
+fi
 
 cat <<EOF >> "${TARGET_DIR}/etc/machine-info"
 PRETTY_HOSTNAME=${hostname_to_write}


### PR DESCRIPTION
After #53 (f312fc741a) decoupled the build type (develop/release) from whether
the build is signed, we also need to decouple the build type from whether the
public code signing cert is present on the build output. If a signing key is
present at build time, the resulting build should include the cert.

## Testing

This is a followup to #53 (that really should have been in #53). The builds we produce now are signed but don't contain the cert required to check the _next_ update's signature. We need to include that cert if we're going to sign the build.

So, testing is installing a build from this branch ( https://opentrons-buildroot-ci.s3.amazonaws.com/1010f8f5-426e-43fc-8354-11e5e3284793/opentrons-buildroot/ot2-system.zip ) and then trying to install an unsigned build (https://opentrons-buildroot-ci.s3.amazonaws.com/1d64aeff-b335-4f27-adb3-2a829ecff3fa/opentrons-buildroot/ot2-system.zip) and checking that there's actually an error.