### PR TITLE
boards/opentrons/ot2: journald conf: sync faster

### DIFF
--- a/board/opentrons/ot2/rootfs-overlay/etc/systemd/journald.conf.d/log_storage.conf
+++ b/board/opentrons/ot2/rootfs-overlay/etc/systemd/journald.conf.d/log_storage.conf
@@ -1,2 +1,3 @@
 [Journal]
 Storage=persistent
+SyncIntervalSec=30s


### PR DESCRIPTION
Users frequently power cycle their machines in response to an error. Since
journald by default syncs to disk every 5 minutes, valuable log data is
frequently lost.

This commit bumps the file sync time to 30 seconds. This is striking a bit of a
balance because journald is not designed to stream to disk, it buffers and then
writes the buffers in a chunk. We may experiment with this value further, but 30
seconds is still better than 5 minutes.

Closes https://github.com/Opentrons/opentrons/issues/4402

## Testing
See if protocols take a lot longer to complete. I'm in general worried about adding extra file churn so just time with this PR active will be helpful.