### PR TITLE
Fix build scripts for building locally on macOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@
 *~
 *.pyc
 .env
+.DS_Store

--- a/board/opentrons/ot2/post-build.sh
+++ b/board/opentrons/ot2/post-build.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -u
 set -e

--- a/opentrons-build.sh
+++ b/opentrons-build.sh
@@ -52,7 +52,9 @@ docker build ${filter_arg} -t ${imgname} .
 env | grep 'CODEBUILD\|AWS\|DATADOG' >.env
 echo "OT_BUILD_TYPE=${OT_BUILD_TYPE-dev}">>.env
 echo "FORCE_UNSAFE_CONFIGURE=1">>.env
-echo "${SIGNING_KEY}" > .signing-key
+if [ "${SIGNING_KEY}" ]; then
+    echo "${SIGNING_KEY}" > .signing-key
+fi
 
 case $# in
     0)


### PR DESCRIPTION
# Overview

This fixes a couple of build errors that I ran into trying to build the repo locally on macOS.

# Changelog

* **When SIGNING_KEY is not provided, don't create a .signing-key file.** This fixes the build breaking when SIGNING_KEY is unset.  post-build.sh would think that a signing key was provided because the file existed, even though it was empty.
* **Use `#!/bin/bash` instead of `#!/bin/sh` in post-build.sh.**  This script does use Bash features - the `[[ ... ]]` syntax, at least.  This did cause an error, but, worryingly, the script would continue execution despite the -e option being set.  Apparently this is normal, documented Bash behavior for an unrecognized command following an if-statement.  :|
* **Add .DS_Store to .gitignore.**