### PR TITLE
Relax consistency guarantees for bind-mounted Docker volumes

### DIFF
--- a/opentrons-build.sh
+++ b/opentrons-build.sh
@@ -28,8 +28,8 @@ trap finish EXIT
 
 DOCKER_BR_BIND_DIR="/buildroot"
 DOCKER_OT_BIND_DIR="/opentrons"
-DOCKER_BIND_BR="--mount type=bind,source=$(pwd),destination=${DOCKER_BR_BIND_DIR}"
-DOCKER_BIND_OT="--mount type=bind,source=$(pwd)/../opentrons,destination=${DOCKER_OT_BIND_DIR}"
+DOCKER_BIND_BR="--mount type=bind,source=$(pwd),destination=${DOCKER_BR_BIND_DIR},consistency=delegated"
+DOCKER_BIND_OT="--mount type=bind,source=$(pwd)/../opentrons,destination=${DOCKER_OT_BIND_DIR},consistency=delegated"
 DOCKER_BIND="${DOCKER_BIND_BR} ${DOCKER_BIND_OT}"
 heads=${@:1:$(($# - 1))}
 tail=${@:$#}


### PR DESCRIPTION
On macOS, this improves the performance of the build from "literally unusuable" to merely "painfully slow."

As a result of this change, bad things may happen if you try to poke around in the build directories while the build is running.  But even with strict consistency, that would have been a bad idea for other reasons.

This shouldn't affect anything on platforms other than macOS.

See: https://docs.docker.com/docker-for-mac/osxfs-caching/