### PR TITLE
package/python-starlette: downgrade to version 0.12.9 

### DIFF
--- a/package/python-starlette/python-starlette.hash
+++ b/package/python-starlette/python-starlette.hash
@@ -1,3 +1,3 @@
 # md5, sha256 from https://pypi.org/pypi/starlette/json
-md5	f264ef9261adf55451755f4e9ee8f878  starlette-0.13.1.tar.gz
-sha256	b5b76bdb34b8073e4ec37e8791e250db9cde99953ca927de452e158c6845dcdd  starlette-0.13.1.tar.gz
+md5	4c55a34f517c39a12283584b6ecb7581  starlette-0.12.9.tar.gz
+sha256	c2ac9a42e0e0328ad20fe444115ac5e3760c1ee2ac1ff8cdb5ec915c4a453411  starlette-0.12.9.tar.gz

--- a/package/python-starlette/python-starlette.mk
+++ b/package/python-starlette/python-starlette.mk
@@ -4,9 +4,9 @@
 #
 ################################################################################
 
-PYTHON_STARLETTE_VERSION = 0.13.1
+PYTHON_STARLETTE_VERSION = 0.12.9
 PYTHON_STARLETTE_SOURCE = starlette-$(PYTHON_STARLETTE_VERSION).tar.gz
-PYTHON_STARLETTE_SITE = https://files.pythonhosted.org/packages/2c/e4/244978c726428c440a333d0cbf68913eb0816a565822fdce3075d1c729f1
+PYTHON_STARLETTE_SITE = https://files.pythonhosted.org/packages/67/95/2220fe5bf287e693a6430d8ee36c681b0157035b7249ec08f8fb36319d16
 PYTHON_STARLETTE_SETUP_TYPE = setuptools
 PYTHON_STARLETTE_LICENSE = BSD-3-Clause
 


### PR DESCRIPTION
We had version 0.13.1 of Starlette as a requiement for fastapi. But fastapi 0.48.0 requires version 0.12.9 of Starlette. 

Looks like the pypi scanner can make mistakes.