### PR TITLE
package/opentrons/opentrons-magnetic-module-firmware: update to v2.0.0

### DIFF
--- a/package/opentrons/opentrons-magnetic-module-firmware/opentrons-magnetic-module-firmware.hash
+++ b/package/opentrons/opentrons-magnetic-module-firmware/opentrons-magnetic-module-firmware.hash
@@ -1,2 +1,2 @@
 # locally computed
-sha256 a975dd30513db4e33c7fec5b600bf3e59be899032ab24c39cbd420df68296b47 mag-deck-arduino.ino.hex
+sha256 05f7e0ec455c2c6087cc463c220ca420ce08ad8dd8b3ab58a2084588231b8f27 mag-deck-arduino.ino.hex

--- a/package/opentrons/opentrons-magnetic-module-firmware/opentrons-magnetic-module-firmware.mk
+++ b/package/opentrons/opentrons-magnetic-module-firmware/opentrons-magnetic-module-firmware.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-OPENTRONS_MAGNETIC_MODULE_FIRMWARE_VERSION=v1.0.2
+OPENTRONS_MAGNETIC_MODULE_FIRMWARE_VERSION=v2.0.0
 OPENTRONS_MAGNETIC_MODULE_FIRMWARE_SOURCE=mag-deck-arduino.ino.hex
 OPENTRONS_MAGNETIC_MODULE_FIRMWARE_SITE=https://opentrons-modules-builds.s3.us-east-2.amazonaws.com/magnetic-module/$(OPENTRONS_MAGNETIC_MODULE_FIRMWARE_VERSION)
 OPENTRONS_MAGNETIC_MODULE_FIRMWARE_LICENSE=Apache-2.0


### PR DESCRIPTION
This PR integrates the Opentrons magnetic module firmware release in https://github.com/Opentrons/opentrons-modules/releases/tag/magdeck%402.0.0