### PR TITLE
upgrade packages for robot-server port to fast api

### DIFF
--- a/package/python-uvicorn/python-uvicorn.hash
+++ b/package/python-uvicorn/python-uvicorn.hash
@@ -1,3 +1,3 @@
 # md5, sha256 from https://pypi.org/pypi/uvicorn/json
-md5	da4bc6a966c559e5f03dbd2d486ad855  uvicorn-0.11.2.tar.gz
-sha256	11f397855c7f35dc034a3d288883382a4c16afdfe6675b70896f55bd6051da64  uvicorn-0.11.2.tar.gz
+md5	985bb2637aa3b7b09df9feb7cd397c58  uvicorn-0.11.3.tar.gz
+sha256	6fdaf8e53bf1b2ddf0fe9ed06079b5348d7d1d87b3365fe2549e6de0d49e631c  uvicorn-0.11.3.tar.gz

--- a/package/python-uvicorn/python-uvicorn.mk
+++ b/package/python-uvicorn/python-uvicorn.mk
@@ -4,9 +4,9 @@
 #
 ################################################################################
 
-PYTHON_UVICORN_VERSION = 0.11.2
+PYTHON_UVICORN_VERSION = 0.11.3
 PYTHON_UVICORN_SOURCE = uvicorn-$(PYTHON_UVICORN_VERSION).tar.gz
-PYTHON_UVICORN_SITE = https://files.pythonhosted.org/packages/5c/ed/37f168f52814d09feaf0b4f6894704a17209f84219773def5b8b14a060dc
+PYTHON_UVICORN_SITE = https://files.pythonhosted.org/packages/48/30/cd48ac0eb03bd3007191ea20fc34457a45187fb430fdc30c0f6b9059bee0
 PYTHON_UVICORN_SETUP_TYPE = setuptools
 
 $(eval $(python-package))

--- a/package/python-uvloop/python-uvloop.hash
+++ b/package/python-uvloop/python-uvloop.hash
@@ -1,6 +1,6 @@
 # md5, sha256 from https://pypi.org/pypi/uvloop/json
-md5	7d509d78b18a5863cc06697ccfd835ad  uvloop-0.11.2.tar.gz
-sha256	a97bd62ebbdf7e6e84bf44afe439d9b24ce4d8661a29a639626a8c03748f6f98  uvloop-0.11.2.tar.gz
+md5	a2f82abb676756f11f544c6b51caf171  uvloop-0.14.0.tar.gz
+sha256	123ac9c0c7dd71464f58f1b4ee0bbd81285d96cdda8bc3519281b8973e3a461e  uvloop-0.14.0.tar.gz
 # Locally computed sha256 checksums
 sha256	2fdc436a67077941295c58647f521fbef8f50e46db0970552fa1a4dd8ae261c6  LICENSE-APACHE
 sha256	9185f3c77e9f6ef8859a6ba4c94128ac1329876be3e813aad32d7645e51ae409  LICENSE-MIT

--- a/package/python-uvloop/python-uvloop.mk
+++ b/package/python-uvloop/python-uvloop.mk
@@ -4,9 +4,9 @@
 #
 ################################################################################
 
-PYTHON_UVLOOP_VERSION = 0.11.2
+PYTHON_UVLOOP_VERSION = 0.14.0
 PYTHON_UVLOOP_SOURCE = uvloop-$(PYTHON_UVLOOP_VERSION).tar.gz
-PYTHON_UVLOOP_SITE = https://files.pythonhosted.org/packages/5c/37/6daa39aac42b2deda6ee77f408bec0419b600e27b89b374b0d440af32b10
+PYTHON_UVLOOP_SITE = https://files.pythonhosted.org/packages/84/2e/462e7a25b787d2b40cf6c9864a9e702f358349fc9cfb77e83c38acb73048
 PYTHON_UVLOOP_SETUP_TYPE = setuptools
 PYTHON_UVLOOP_LICENSE = Apache-2.0, MIT
 PYTHON_UVLOOP_LICENSE_FILES = LICENSE-APACHE LICENSE-MIT

--- a/package/python-websockets/python-websockets.hash
+++ b/package/python-websockets/python-websockets.hash
@@ -1,5 +1,5 @@
 # md5, sha256 from https://pypi.org/pypi/websockets/json
-md5	76cf931a525a3415f5a4f59c133e89c3  websockets-6.0.tar.gz
-sha256	8f3b956d11c5b301206382726210dc1d3bee1a9ccf7aadf895aaf31f71c3716c  websockets-6.0.tar.gz
+md5	f12d7f31fe8d0b3e65c12f845bcd0ad8  websockets-8.1.tar.gz
+sha256	5c65d2da8c6bce0fca2528f69f44b2f977e06954c8512a952222cea50dad430f  websockets-8.1.tar.gz
 # Locally computed sha256 checksums
 sha256	2cd4d416e432ca7fda2c103b38b852f8d3cb327d70c3db44410b9fe97e6c4d73  LICENSE

--- a/package/python-websockets/python-websockets.mk
+++ b/package/python-websockets/python-websockets.mk
@@ -4,9 +4,9 @@
 #
 ################################################################################
 
-PYTHON_WEBSOCKETS_VERSION = 6.0
+PYTHON_WEBSOCKETS_VERSION = 8.1
 PYTHON_WEBSOCKETS_SOURCE = websockets-$(PYTHON_WEBSOCKETS_VERSION).tar.gz
-PYTHON_WEBSOCKETS_SITE = https://files.pythonhosted.org/packages/4e/2a/56e60bb4c3696bc736998cc13c3fa1a36210609d7e1a3f2519857b420245
+PYTHON_WEBSOCKETS_SITE = https://files.pythonhosted.org/packages/e9/2b/cf738670bb96eb25cb2caf5294e38a9dc3891a6bcd8e3a51770dbc517c65
 PYTHON_WEBSOCKETS_SETUP_TYPE = setuptools
 PYTHON_WEBSOCKETS_LICENSE = BSD-3-Clause
 PYTHON_WEBSOCKETS_LICENSE_FILES = LICENSE


### PR DESCRIPTION
A number of issues:
- Uvicorn requires version 0.14.0 of uvloop
- Uvicorn requires version >=0.8.0 of websockets
- Uvicorn 0.11.2 had a minor bug that was fixed in 0.11.3