### PR TITLE
ot-blinkenlights refactor: use libgpiod

### DIFF
--- a/board/opentrons/ot2/rootfs-overlay/usr/bin/ot-blinkenlights
+++ b/board/opentrons/ot2/rootfs-overlay/usr/bin/ot-blinkenlights
@@ -1,31 +1,21 @@
 #!/usr/bin/env python3
 
-import importlib
 import os
-import sys
 import time
 import signal
 
-ot = importlib.find_loader('opentrons')
-ot_root = os.path.dirname(ot.get_filename())
+import gpiod
 
-gpio_path = os.path.join(ot_root, 'drivers', 'rpi_drivers')
-sys.path.insert(0, gpio_path)
+CHIP = 'gpiochip0'
+BLUE_BUTTON = 13
 
-import gpio
-
-gpio.robot_startup_sequence()
-
-def handleSignal(signal_number, frame):
-    gpio.set_button_light(blue=True)
-    os._exit(0)
-
-signal.signal(signal.SIGTERM, handleSignal)
-signal.signal(signal.SIGINT, handleSignal)
+chip = gpiod.Chip(CHIP)
+line = chip.get_line(BLUE_BUTTON)
+line.request(consumer='ot-blinkenlights', type=gpiod.LINE_REQ_DIR_OUT)
 
 # Start blinking button blue
 while True:
-    gpio.set_button_light(blue=True)
+    line.set_value(1)
     time.sleep(0.5)
-    gpio.set_button_light()
+    line.set_value(0)
     time.sleep(0.5)


### PR DESCRIPTION
This PR updates the ot-blinkenlights script (used in opentrons-gpio-setup.service) by using libgpiod to control gpios, instead of using the legacy sysfs interface.

This is part of the OT2 refresh project and is required for this specific ticket: https://github.com/Opentrons/opentrons/issues/5310

