### PR TITLE
board/opentrons/ot2: add wifi mac config to NetworkManager

### DIFF
--- a/board/opentrons/ot2/rootfs-overlay/etc/NetworkManager/conf.d/wifi_rand_mac.conf
+++ b/board/opentrons/ot2/rootfs-overlay/etc/NetworkManager/conf.d/wifi_rand_mac.conf
@@ -1,0 +1,2 @@
+[device]
+wifi.scan-rand-mac-address=no


### PR DESCRIPTION
Closes [#4758](https://github.com/Opentrons/opentrons/issues/4758)

Disables randomization of wifi mac while in scan mode.