### PR TITLE
package/systemd: create /etc/resolv.conf only if resolved is selected

### DIFF
--- a/package/systemd/systemd.mk
+++ b/package/systemd/systemd.mk
@@ -285,10 +285,6 @@ endif
 ifeq ($(BR2_PACKAGE_SYSTEMD_NETWORKD),y)
 SYSTEMD_CONF_OPTS += -Dnetworkd=true
 SYSTEMD_NETWORKD_USER = systemd-network -1 systemd-network -1 * - - - Network Manager
-define SYSTEMD_INSTALL_RESOLVCONF_HOOK
-	ln -sf ../run/systemd/resolve/resolv.conf \
-		$(TARGET_DIR)/etc/resolv.conf
-endef
 SYSTEMD_NETWORKD_DHCP_IFACE = $(call qstrip,$(BR2_SYSTEM_DHCP))
 ifneq ($(SYSTEMD_NETWORKD_DHCP_IFACE),)
 define SYSTEMD_INSTALL_NETWORK_CONFS
@@ -302,6 +298,10 @@ SYSTEMD_CONF_OPTS += -Dnetworkd=false
 endif
 
 ifeq ($(BR2_PACKAGE_SYSTEMD_RESOLVED),y)
+define SYSTEMD_INSTALL_RESOLVCONF_HOOK
+	ln -sf ../run/systemd/resolve/resolv.conf \
+		$(TARGET_DIR)/etc/resolv.conf
+endef
 SYSTEMD_CONF_OPTS += -Dresolve=true
 SYSTEMD_RESOLVED_USER = systemd-resolve -1 systemd-resolve -1 * - - - Network Name Resolution Manager
 else


### PR DESCRIPTION
This PR from @sfoster1 cherry picks https://github.com/buildroot/buildroot/commit/0e51737575bcfbe573c8fe156f1e4a5408aad0fa to fix the exact issue described in the commit

> **package/systemd: create /etc/resolv.conf only if resolved is selected**
>
> Or else it becomes a dangling link to
> /run/systemd/resolve/resolv.conf, which is never created. Even worst,
> it also prevents NetworkManager from updating resolv.conf.
> 
> Fixes:
>   https://bugs.busybox.net/show_bug.cgi?id=9881
>
> Signed-off-by: Carlos Santos <unixmania@gmail.com>
> Reviewed-by: Yann E. MORIN <yann.morin.1998@free.fr>
> Signed-off-by: Thomas Petazzoni <thomas.petazzoni@bootlin.com>

As found by @sanni-t, with the removal of `systemd-networkd` in #94, this bug meant the symlink that connects `NetworkManager` to `systemd-resolved` was never created. Without this symlink, DNS resolution on the robot is completely broken, which breaks all sorts of stuff, including but not limited to:

- Connecting to time servers
- `pip install`ing anything
- Ok yeah anything that uses any domain name