### PR TITLE
board/opentrons/ot2: enable status leds service, exit service gracefully on non-refresh

### DIFF
--- a/board/opentrons/ot2/rootfs-overlay/etc/systemd/system/basic.target.wants/opentrons-status-leds.service
+++ b/board/opentrons/ot2/rootfs-overlay/etc/systemd/system/basic.target.wants/opentrons-status-leds.service
@@ -1,0 +1,1 @@
+../opentrons-status-leds.service

--- a/board/opentrons/ot2/rootfs-overlay/usr/bin/ot-status-leds
+++ b/board/opentrons/ot2/rootfs-overlay/usr/bin/ot-status-leds
@@ -269,14 +269,17 @@ async def main():
     """ If we have a refresh board, initialize LEDs
         and run status update tasks
     """
+    refresh_board = is_refresh_board()
+
+    """Systemd can start next service once revision pins have been read. """
+    systemdd_notify()
+
     if not is_refresh_board():
         log.info("Not a refresh board. Exiting status lights service.")
         exit(0)
-
-    systemdd_notify()   # Notify systemd so that it can move to next service
-    log.info("Refresh board found. Starting status LEDs service.")
-    init_leds()
-
-    await asyncio.gather(blink_heartbeat_led(), update_nw_status_leds())
+    else:
+        log.info("Refresh board found. Starting status LEDs service.")
+        init_leds()
+        await asyncio.gather(blink_heartbeat_led(), update_nw_status_leds())
 
 asyncio.run(main())

--- a/board/opentrons/ot2/rootfs-overlay/usr/bin/ot-status-leds
+++ b/board/opentrons/ot2/rootfs-overlay/usr/bin/ot-status-leds
@@ -271,10 +271,11 @@ async def main():
     """
     refresh_board = is_refresh_board()
 
-    """Systemd can start next service once revision pins have been read. """
+    # Systemd can start next service once revision pins have been read.
+    # Necessary to avoid pin access conflict with the next service (opentrons-robot-server)
     systemdd_notify()
 
-    if not is_refresh_board():
+    if not refresh_board:
         log.info("Not a refresh board. Exiting status lights service.")
         exit(0)
     else:


### PR DESCRIPTION
Closes #119

## overview
Follow-up to #116 

## changes
- enables the status leds service by default
- On non-refresh robots, the service exits gracefully and doesn't restart

## review request
- Please make sure the above changes are actually observed
