### PR TITLE
board/opentrons/ot2: Read time from RTC at boot

### DIFF
--- a/board/opentrons/ot2/rootfs-overlay/etc/udev/rules.d/97-rtc-hctosys.rules
+++ b/board/opentrons/ot2/rootfs-overlay/etc/udev/rules.d/97-rtc-hctosys.rules
@@ -1,0 +1,1 @@
+ACTION=="add", SUBSYSTEM=="rtc", RUN+="/sbin/hwclock --hctosys --utc"


### PR DESCRIPTION
Closes #126 

# overview:

This PR adds a udev rules file that, upon encountering an RTC device, sets the system clock from the RTC.

# review request

Build files:
- [ot2-fullimage.zip](https://opentrons-buildroot-ci.s3.amazonaws.com/d80ac9d3-292e-4f39-a9ec-bfe06ada11c7/opentrons-buildroot/ot2-fullimage.zip)
- [ot2-system.zip](https://opentrons-buildroot-ci.s3.amazonaws.com/d80ac9d3-292e-4f39-a9ec-bfe06ada11c7/opentrons-buildroot/ot2-system.zip)

1. On a refresh robot, make sure you are not connected to the internet, and set your system clock to a stale time e.g. `date --set "2020-01-01 02:02:02"`. `timedatectl` should now show system clock as set above while RTC time still correct. Power cycle the robot. Once done booting, `timedatectl` should show system clock and RTC to be same and correct.
2. On non-refresh robot, grep for 'rtc' in system logs and verify that there are no errors logged.

# extra review
- Before merging into main branch, it is probably best to check if we can push api or robot server changes to this fs. A rootfs with very little size left gives errors when trying to make any changes.