### PR TITLE
fix(buildroot): disallow capital letters in image names by automatically converting to lowercase

### DIFF
--- a/opentrons-build.sh
+++ b/opentrons-build.sh
@@ -46,7 +46,7 @@ fi
 
 imgname=opentrons-buildroot-$(git describe --all --dirty --always)
 
-docker build ${filter_arg} -t ${imgname} .
+docker build ${filter_arg} -t ${imgname,,} .
 
 # Save codebuild-relevant env vars to get them inside docker
 env | grep 'CODEBUILD\|AWS\|DATADOG' >.env

--- a/opentrons-build.sh
+++ b/opentrons-build.sh
@@ -44,9 +44,10 @@ then
     export DATADOG_API_KEY=$(./get_parameter.py /buildroot-codebuild/datadog-api -)
 fi
 
-imgname=opentrons-buildroot-$(git describe --all --dirty --always)
+githubname="$(git describe --all --dirty --always | tr '[:upper:]' '[:lower:]')"
+imgname=opentrons-buildroot-${githubname}
 
-docker build ${filter_arg} -t ${imgname,,} .
+docker build ${filter_arg} -t ${imgname} .
 
 # Save codebuild-relevant env vars to get them inside docker
 env | grep 'CODEBUILD\|AWS\|DATADOG' >.env


### PR DESCRIPTION
## Overview
Docker does not like when image names have capital letters in them. Instead of throwing an error we should just automatically ensure that all branch names are lower case when building the docker image.


## Review requests
I think buildroot is on bash version 4+? The {,,} syntax is only available on that version. I can use `tr` otherwise if we think that's safer.