### PR TITLE
chore: Pin Docker to Debian 10 to work around out-of-date Buildroot

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,9 @@
-FROM debian:stable-slim
+FROM debian:10-slim
+# We're stuck on Debian 10 (which will go EOL around 2022-08) because
+# Debian 11 upgrades GNU Make to v4.3, which breaks Buildroot's build system.
+#
+# Upstream Buildroot has fixes for this (try grepping their CHANGES file for
+# "4.3"), but those commits aren't currently in this fork.
 
 ARG filter_output
 


### PR DESCRIPTION
# Overview

Attempts to fix build failures in CI.

# Details

We were seeing build failures in CI like:

> No rule to make target '/buildroot/output/.br-external.mk`

This appears to have been caused by:

* Debian having recently released a new stable version, Debian 11.
* Our Docker image, debian:stable-slim, having auto-updated to track Debian 11.
* Debian 11 having updated GNU Make from v4.2.1 to v4.3.
* Our Buildroot fork missing several upstream commits to fix compatibility with GNU Make v4.3. (Try grepping upstream’s CHANGES file for "4.3".)

As a quick fix, this pins our docker image to Debian 10 so we get Make v4.2.1 back. Unfortunately, Debian doesn't really support installing an old version of a single package, so it's all-or-nothing. See https://unix.stackexchange.com/a/544434/7421.

# Review requests

* Does it seem like this has fixed the build problem?
* Do we agree that pinning to Debian 10 is the correct thing to do, for now?