### PR TITLE
chore(opentrons-build): fix build script if no env vars imported

### DIFF
--- a/opentrons-build.sh
+++ b/opentrons-build.sh
@@ -34,13 +34,11 @@ DOCKER_BIND="${DOCKER_BIND_BR} ${DOCKER_BIND_OT}"
 heads=${@:1:$(($# - 1))}
 tail=${@:$#}
 
-if [ -n "$CI" ]
-then
+if [ -n "$CI" ]; then
    filter_arg="--build-arg filter_output=true"
 fi
 
-if [ -n "$DATADOG_API_KEY"]
-then
+if [ -n "$DATADOG_API_KEY" ]; then
     export DATADOG_API_KEY=$(./get_parameter.py /buildroot-codebuild/datadog-api -)
 fi
 
@@ -50,9 +48,11 @@ imgname=opentrons-buildroot-${githubname}
 docker build ${filter_arg} -t ${imgname} .
 
 # Save codebuild-relevant env vars to get them inside docker
-env | grep 'CODEBUILD\|AWS\|DATADOG' >.env
-echo "OT_BUILD_TYPE=${OT_BUILD_TYPE-dev}">>.env
-echo "FORCE_UNSAFE_CONFIGURE=1">>.env
+codebuild_args=$(env | grep 'CODEBUILD\|AWS\|DATADOG') || true
+
+echo ${codebuild_args} > .env
+echo "OT_BUILD_TYPE=${OT_BUILD_TYPE-dev}" >> .env
+echo "FORCE_UNSAFE_CONFIGURE=1" >> .env
 if [ "${SIGNING_KEY}" ]; then
     echo "${SIGNING_KEY}" > .signing-key
 fi


### PR DESCRIPTION
## Overview

If `grep` finds no matches, it exits with the exit code `1`. Our build script greps through `env` to grab any relevant env vars to pass to the build. If there are no env vars to forward (which is likely if building locally) the build script errors out instead of doing anything.

This PR fixes that issue to allow local builds when no matching env vars are found