### PR TITLE
build: fix datadog env var and exit codes

### DIFF
--- a/in_docker.sh
+++ b/in_docker.sh
@@ -8,7 +8,7 @@ set -e
 set -v
 
 targets=$@
-filtered_build_log="/buildroot/buildlog,txt"
+filtered_build_log="/buildroot/buildlog.txt"
 filtered_warnings_log="/buildroot/warnings.txt"
 
 function finish {

--- a/in_docker.sh
+++ b/in_docker.sh
@@ -6,11 +6,22 @@
 set -o pipefail
 set -e
 set -v
+
 targets=$@
-if [ -n "$FILTER" ]
-then
+filtered_build_log="/buildroot/buildlog,txt"
+filtered_warnings_log="/buildroot/warnings.txt"
+
+function finish {
+    if [[ -f "${filtered_warnings_log}" ]]; then
+        cat ${filtered_warnings_log}
+    fi
+}
+
+trap finish EXIT
+
+if [[ -n "${FILTER}" ]]; then
    echo "in ci"
-   for w in $@
+   for w in $@;
    do
        case "$w" in
            "all")
@@ -26,11 +37,10 @@ then
    done;
 fi
 
-if [ -z $filter ]
-then
+if [[ -z "${filter}" ]]; then
     echo "Unfiltered make"
     BR2_EXTERNAL=/opentrons make -C /buildroot $@
 else
     echo "Filtered make"
-    (BR2_EXTERNAL=/opentrons make -C /buildroot $@ 2>/buildroot/warnings.txt | awk '/^make/;{print $0 >>"/buildroot/buildlog.txt"}') || cat warnings.txt
+    BR2_EXTERNAL=/opentrons make -C /buildroot $@ 2>${filtered_warnings_log} | awk "/^make/;{print $0 >>\"${filtered_build_log}\"}"
 fi

--- a/in_docker.sh
+++ b/in_docker.sh
@@ -21,8 +21,7 @@ trap finish EXIT
 
 if [[ -n "${FILTER}" ]]; then
    echo "in ci"
-   for w in $@;
-   do
+   for w in $@; do
        case "$w" in
            "all")
                filter=1

--- a/opentrons-build.sh
+++ b/opentrons-build.sh
@@ -47,11 +47,10 @@ imgname=opentrons-buildroot-${githubname}
 docker build ${filter_arg} -t ${imgname} .
 
 # Save codebuild-relevant env vars to get them inside docker
-codebuild_args=$(env | grep 'CODEBUILD\|AWS\|DATADOG') || true
-
-echo ${codebuild_args} > .env
+env | grep 'CODEBUILD\|AWS\|DATADOG' > .env
 echo "OT_BUILD_TYPE=${OT_BUILD_TYPE-dev}" >> .env
 echo "FORCE_UNSAFE_CONFIGURE=1" >> .env
+
 if [[ -n "${SIGNING_KEY}" ]]; then
     echo "${SIGNING_KEY}" > .signing-key
 fi

--- a/opentrons-build.sh
+++ b/opentrons-build.sh
@@ -21,7 +21,6 @@ set -e -o pipefail
 
 function finish {
     rm -f .signing-key
-    exit $?
 }
 
 trap finish EXIT

--- a/opentrons-build.sh
+++ b/opentrons-build.sh
@@ -34,11 +34,11 @@ DOCKER_BIND="${DOCKER_BIND_BR} ${DOCKER_BIND_OT}"
 heads=${@:1:$(($# - 1))}
 tail=${@:$#}
 
-if [ -n "$CI" ]; then
+if [[ -n "${CI}" ]]; then
    filter_arg="--build-arg filter_output=true"
 fi
 
-if [ -n "$DATADOG_API_KEY" ]; then
+if [[ -z "${DATADOG_API_KEY}" ]]; then
     export DATADOG_API_KEY=$(./get_parameter.py /buildroot-codebuild/datadog-api -)
 fi
 
@@ -53,7 +53,7 @@ codebuild_args=$(env | grep 'CODEBUILD\|AWS\|DATADOG') || true
 echo ${codebuild_args} > .env
 echo "OT_BUILD_TYPE=${OT_BUILD_TYPE-dev}" >> .env
 echo "FORCE_UNSAFE_CONFIGURE=1" >> .env
-if [ "${SIGNING_KEY}" ]; then
+if [[ -n "${SIGNING_KEY}" ]]; then
     echo "${SIGNING_KEY}" > .signing-key
 fi
 


### PR DESCRIPTION
## Overview

This PR is a follow-up to #133, which inadvertently exposed an unnoticed bug and introduced an exciting new bug.

It makes the following changes:

- (Bug fix, old bug) Make sure datadog env var is exported if needed
- (Bug fix, new bug) Reverts 133, because it broke the `.env` by making everything space-delimited instead of newline-delimited
- (Build improvement) Ensure build script exits with the right code so the build is marked as a failure if it fails