### PR TITLE
board/opentrons/ot2: udev rules for heater-shaker

### DIFF
--- a/board/opentrons/ot2/rootfs-overlay/etc/udev/rules.d/95-opentrons-modules.rules
+++ b/board/opentrons/ot2/rootfs-overlay/etc/udev/rules.d/95-opentrons-modules.rules
@@ -5,3 +5,5 @@ KERNEL=="ttyACM[0-9]*", SUBSYSTEMS=="usb", ATTRS{idProduct}=="ed8c", ATTRS{idVen
 KERNEL=="ttyACM[0-9]*", SUBSYSTEMS=="usb", ATTRS{idProduct}=="ed12", ATTRS{idVendor}=="04d8", SYMLINK+="ot_module_samba_bootloader%n"
 # adafruit feather m0 board for dev:
 KERNEL=="ttyACM[0-9]*", SUBSYSTEMS=="usb", ATTRS{idProduct}=="800b", ATTRS{idVendor}=="239a", SYMLINK+="ot_module_thermocycler%n"
+KERNEL=="ttyACM[0-9]*", SUBSYSTEMS=="usb", ATTRS{idProduct}=="4853", ATTRS{idVendor}=="0483", SYMLINK+="ot_module_heatershaker%n"
+KERNEL=="ttyACM[0-9]*", SUBSYSTEMS=="usb", ATTRS{idProduct}=="0438", ATTRS{idVendor}=="0483", SYMLINK+="ot_module_heatershaker_bootloader%n"


### PR DESCRIPTION
We need to add the VID and PID to the symlink creation list for udev so
the server can detect a heater shaker.