### PR TITLE
board/opentrons/ot2: Work around RV-3028 problems via artificial delay

### DIFF
--- a/board/opentrons/ot2/kernel-patches/0008-Work-around-rv3028-problems-via-artificial-delay.patch
+++ b/board/opentrons/ot2/kernel-patches/0008-Work-around-rv3028-problems-via-artificial-delay.patch
@@ -18,6 +18,9 @@ bus time in order to apply postponed time updates.
 
 See Opentrons Jira RSS-9 for investigation details.
 
+We sleep for 2-4 milliseconds. Shorter sleeps might also work;
+we just haven't tested with them.
+
 ---
  drivers/rtc/rtc-rv3028.c | 6 ++++++
  1 file changed, 6 insertions(+)

--- a/board/opentrons/ot2/kernel-patches/0008-Work-around-rv3028-problems-via-artificial-delay.patch
+++ b/board/opentrons/ot2/kernel-patches/0008-Work-around-rv3028-problems-via-artificial-delay.patch
@@ -30,7 +30,7 @@ index a714e5aeefb8..d499a2e5d956 100644
 --- a/drivers/rtc/rtc-rv3028.c
 +++ b/drivers/rtc/rtc-rv3028.c
 @@ -10,6 +10,7 @@
-
+ 
  #include <linux/bcd.h>
  #include <linux/bitops.h>
 +#include <linux/delay.h>
@@ -38,9 +38,9 @@ index a714e5aeefb8..d499a2e5d956 100644
  #include <linux/interrupt.h>
  #include <linux/kernel.h>
 @@ -79,6 +80,9 @@
-
+ 
  #define OFFSET_STEP_PPT            953674
-
+ 
 +#define WORKAROUND_SLEEP_MIN_US        2000
 +#define WORKAROUND_SLEEP_MAX_US        4000
 +
@@ -50,12 +50,12 @@ index a714e5aeefb8..d499a2e5d956 100644
 @@ -227,6 +231,8 @@ static int rv3028_get_time(struct device *dev, struct rtc_time *tm)
         return -EINVAL;
     }
-
+ 
 +   usleep_range(WORKAROUND_SLEEP_MIN_US, WORKAROUND_SLEEP_MAX_US);
 +
     ret = regmap_bulk_read(rv3028->regmap, RV3028_SEC, date, sizeof(date));
     if (ret)
         return ret;
---
+-- 
 2.37.1
 

--- a/board/opentrons/ot2/kernel-patches/0008-Work-around-rv3028-problems-via-artificial-delay.patch
+++ b/board/opentrons/ot2/kernel-patches/0008-Work-around-rv3028-problems-via-artificial-delay.patch
@@ -1,6 +1,11 @@
-This is an Opentrons workaround for what we suspect is an undocumented silicon
-erratum in the RV-3028 RTC. It adds an artificial sleep whenever something
-reads the current time from the RTC's registers.
+From 16292687fd316543bba3d0d0179c2439a85acb6a Mon Sep 17 00:00:00 2001
+From: Max Marrone <max@opentrons.com>
+Date: Mon, 8 Aug 2022 15:34:12 -0400
+Subject: [PATCH] Work around RV-3028 problems via artificial delay
+
+This is an Opentrons workaround for what we suspect is an undocumented
+silicon erratum in the RV-3028 RTC. It adds an artificial sleep whenever
+something reads the current time from the RTC's registers.
 
 Whenever there is an open I2C transaction, the RV-3028 will hold its
 time registers steady, in order to avoid a torn read/write hazard.
@@ -20,7 +25,6 @@ See Opentrons Jira RSS-9 for investigation details.
 
 We sleep for 2-4 milliseconds. Shorter sleeps might also work;
 we just haven't tested with them.
-
 ---
  drivers/rtc/rtc-rv3028.c | 6 ++++++
  1 file changed, 6 insertions(+)
@@ -39,23 +43,23 @@ index a714e5aeefb8..d499a2e5d956 100644
  #include <linux/kernel.h>
 @@ -79,6 +80,9 @@
  
- #define OFFSET_STEP_PPT            953674
+ #define OFFSET_STEP_PPT			953674
  
-+#define WORKAROUND_SLEEP_MIN_US        2000
-+#define WORKAROUND_SLEEP_MAX_US        4000
++#define WORKAROUND_SLEEP_MIN_US		2000
++#define WORKAROUND_SLEEP_MAX_US		4000
 +
  enum rv3028_type {
-    rv_3028,
+ 	rv_3028,
  };
 @@ -227,6 +231,8 @@ static int rv3028_get_time(struct device *dev, struct rtc_time *tm)
-        return -EINVAL;
-    }
+ 		return -EINVAL;
+ 	}
  
-+   usleep_range(WORKAROUND_SLEEP_MIN_US, WORKAROUND_SLEEP_MAX_US);
++	usleep_range(WORKAROUND_SLEEP_MIN_US, WORKAROUND_SLEEP_MAX_US);
 +
-    ret = regmap_bulk_read(rv3028->regmap, RV3028_SEC, date, sizeof(date));
-    if (ret)
-        return ret;
+ 	ret = regmap_bulk_read(rv3028->regmap, RV3028_SEC, date, sizeof(date));
+ 	if (ret)
+ 		return ret;
 -- 
 2.37.1
 

--- a/board/opentrons/ot2/kernel-patches/0008-Work-around-rv3028-problems-via-artificial-delay.patch
+++ b/board/opentrons/ot2/kernel-patches/0008-Work-around-rv3028-problems-via-artificial-delay.patch
@@ -1,0 +1,67 @@
+This is an Opentrons workaround for the RV-3028 RTC.
+It adds an artificial delay whenever something tries to read the RTC's current time.
+See the source comment and Opentrons Jira RSS-9 for details.
+
+---
+ drivers/rtc/rtc-rv3028.c | 31 +++++++++++++++++++++++++++++++
+ 1 file changed, 31 insertions(+)
+
+diff --git a/drivers/rtc/rtc-rv3028.c b/drivers/rtc/rtc-rv3028.c
+index a714e5aeefb8..c14014a253ea 100644
+--- a/drivers/rtc/rtc-rv3028.c
++++ b/drivers/rtc/rtc-rv3028.c
+@@ -10,6 +10,7 @@
+ 
+ #include <linux/bcd.h>
+ #include <linux/bitops.h>
++#include <linux/delay.h>
+ #include <linux/i2c.h>
+ #include <linux/interrupt.h>
+ #include <linux/kernel.h>
+@@ -79,6 +80,10 @@
+ 
+ #define OFFSET_STEP_PPT			953674
+ 
++// 2000 us was chosen because it's the maximum supported by udelay() on ARM.
++// Shorter delays might work, but we haven't tested with them.
++#define WORKAROUND_DELAY_US		2000
++
+ enum rv3028_type {
+ 	rv_3028,
+ };
+@@ -227,6 +232,32 @@ static int rv3028_get_time(struct device *dev, struct rtc_time *tm)
+ 		return -EINVAL;
+ 	}
+ 
++	// NOTE(max@opentrons.com, 2022-08-04):
++	//
++	// To work around a suspected undocumented RV-3028 silicon erratum,
++	// we let the RV-3028 rest before we read its time registers.
++	//
++	// Whenever there is an open I2C transaction, the RV-3028 will hold its
++	// time registers steady, in order to avoid a torn read/write hazard.
++	// If the time registers would have ticked to a new value during that
++	// transaction, the RV-3028 is supposed to postpone that update and
++	// apply it as soon as the transaction ends.
++	//
++	// But on some boards, we're seeing the time registers never update at
++	// all whenever they're under rapid polling. `hwclock` does rapid
++	// polling under normal usage, so this causes it to error with
++	// "Timed out waiting for time change".
++	//
++	// We theorize that problematic RV-3028 chips need a big block of idle
++	// bus time in order to apply postponed time updates.
++	//
++	// See Opentrons Jira RSS-9 for investigation details.
++	//
++	// We use udelay() instead of usleep() because timers-howto.txt says
++	// we must use udelay() when we're in an atomic context. I don't know if
++	// we're in an atomic context here, so I'm assuming yes to be safe.
++	udelay(WORKAROUND_DELAY_US);
++
+ 	ret = regmap_bulk_read(rv3028->regmap, RV3028_SEC, date, sizeof(date));
+ 	if (ret)
+ 		return ret;
+-- 
+2.37.1
+

--- a/board/opentrons/ot2/kernel-patches/0008-Work-around-rv3028-problems-via-artificial-delay.patch
+++ b/board/opentrons/ot2/kernel-patches/0008-Work-around-rv3028-problems-via-artificial-delay.patch
@@ -1,67 +1,58 @@
-This is an Opentrons workaround for the RV-3028 RTC.
-It adds an artificial delay whenever something tries to read the RTC's current time.
-See the source comment and Opentrons Jira RSS-9 for details.
+This is an Opentrons workaround for what we suspect is an undocumented silicon
+erratum in the RV-3028 RTC. It adds an artificial sleep whenever something
+reads the current time from the RTC's registers.
+
+Whenever there is an open I2C transaction, the RV-3028 will hold its
+time registers steady, in order to avoid a torn read/write hazard.
+If the time registers would have ticked to a new value during that
+transaction, the RV-3028 is supposed to postpone that update and
+apply it as soon as the transaction ends.
+
+But on some boards, we're seeing the time registers never update at
+all whenever they're under rapid polling. `hwclock` does rapid
+polling under normal usage, so this causes it to error with
+"Timed out waiting for time change".
+
+We theorize that problematic RV-3028 chips need a big block of idle
+bus time in order to apply postponed time updates.
+
+See Opentrons Jira RSS-9 for investigation details.
 
 ---
- drivers/rtc/rtc-rv3028.c | 31 +++++++++++++++++++++++++++++++
- 1 file changed, 31 insertions(+)
+ drivers/rtc/rtc-rv3028.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
 
 diff --git a/drivers/rtc/rtc-rv3028.c b/drivers/rtc/rtc-rv3028.c
-index a714e5aeefb8..c14014a253ea 100644
+index a714e5aeefb8..d499a2e5d956 100644
 --- a/drivers/rtc/rtc-rv3028.c
 +++ b/drivers/rtc/rtc-rv3028.c
 @@ -10,6 +10,7 @@
- 
+
  #include <linux/bcd.h>
  #include <linux/bitops.h>
 +#include <linux/delay.h>
  #include <linux/i2c.h>
  #include <linux/interrupt.h>
  #include <linux/kernel.h>
-@@ -79,6 +80,10 @@
- 
- #define OFFSET_STEP_PPT			953674
- 
-+// 2000 us was chosen because it's the maximum supported by udelay() on ARM.
-+// Shorter delays might work, but we haven't tested with them.
-+#define WORKAROUND_DELAY_US		2000
+@@ -79,6 +80,9 @@
+
+ #define OFFSET_STEP_PPT            953674
+
++#define WORKAROUND_SLEEP_MIN_US        2000
++#define WORKAROUND_SLEEP_MAX_US        4000
 +
  enum rv3028_type {
- 	rv_3028,
+    rv_3028,
  };
-@@ -227,6 +232,32 @@ static int rv3028_get_time(struct device *dev, struct rtc_time *tm)
- 		return -EINVAL;
- 	}
- 
-+	// NOTE(max@opentrons.com, 2022-08-04):
-+	//
-+	// To work around a suspected undocumented RV-3028 silicon erratum,
-+	// we let the RV-3028 rest before we read its time registers.
-+	//
-+	// Whenever there is an open I2C transaction, the RV-3028 will hold its
-+	// time registers steady, in order to avoid a torn read/write hazard.
-+	// If the time registers would have ticked to a new value during that
-+	// transaction, the RV-3028 is supposed to postpone that update and
-+	// apply it as soon as the transaction ends.
-+	//
-+	// But on some boards, we're seeing the time registers never update at
-+	// all whenever they're under rapid polling. `hwclock` does rapid
-+	// polling under normal usage, so this causes it to error with
-+	// "Timed out waiting for time change".
-+	//
-+	// We theorize that problematic RV-3028 chips need a big block of idle
-+	// bus time in order to apply postponed time updates.
-+	//
-+	// See Opentrons Jira RSS-9 for investigation details.
-+	//
-+	// We use udelay() instead of usleep() because timers-howto.txt says
-+	// we must use udelay() when we're in an atomic context. I don't know if
-+	// we're in an atomic context here, so I'm assuming yes to be safe.
-+	udelay(WORKAROUND_DELAY_US);
+@@ -227,6 +231,8 @@ static int rv3028_get_time(struct device *dev, struct rtc_time *tm)
+        return -EINVAL;
+    }
+
++   usleep_range(WORKAROUND_SLEEP_MIN_US, WORKAROUND_SLEEP_MAX_US);
 +
- 	ret = regmap_bulk_read(rv3028->regmap, RV3028_SEC, date, sizeof(date));
- 	if (ret)
- 		return ret;
--- 
+    ret = regmap_bulk_read(rv3028->regmap, RV3028_SEC, date, sizeof(date));
+    if (ret)
+        return ret;
+--
 2.37.1
 


### PR DESCRIPTION
# Overview

This PR works around problems with the OT-2 Refresh's RV-3028 realtime clock (RTC).

It patches the RTC's device driver in the Linux kernel. Whenever something tries to read the RTC's current time, we add an artificial delay.

See the source comment for details about how this works and why we do it. See Jira RSS-9 for more background on the investigation.

# Review requests

It will be easier to view the code changes here:

https://github.com/SyntaxColoring/linux-rv3028-hacking/compare/opentrons-buildroot-v1.7.0-with-patches...SyntaxColoring:linux-rv3028-hacking:rv3028_hacking

Those are the Git commits that I generated this patch file from.

* [ ] This is baby's first kernel patch. Does my code look correct?
* [ ] In terms of buildroot config, is this patch file thing the best way to apply these changes?
* [x] At the I2C level, does this actually have the intended effect of inserting a 2 ms delay before each read of the time registers?
    * Verified by @SyntaxColoring with a logic analyzer.
* [x] Does this actually let the `hwclock` commands used by `ot2-factory-tools` succeed on problematic boards?
    * Verified by @SyntaxColoring and by the Shenzhen team.
    * Technically should be verified again with the `usleep_range()` changes discussed in the review comments below, but I'm pretty confident that it's fine. I'll double-check again when we release this to the factory, just to be safe.

# Risk analysis

This is pretty risky. We're messing with kernel code, so there's really no bound to the damage we can do if we screw something up. :)

# What merging this PR means

This PR will be merged into `opentrons-develop`. So, it will get pushed into the field whenever we tag our next buildroot release and whenever the next robot software release comes out and bundles it. There's no rush for this, because the problem does not affect any robots currently in the field—it only affects robots on the assembly line.

To get this workaround to robots on the assembly line, we will probably need to backport this fix to [our v1.7 buildroot release](https://github.com/Opentrons/buildroot/releases/tag/v1.7.0), since that's what the factory is using. We'll do this separately after this PR passes code review.