### PR TITLE
chore(heater-shaker): update heater-shaker version to v1.0.3

### DIFF
--- a/package/opentrons/opentrons-heater-shaker-firmware/opentrons-heater-shaker-firmware.hash
+++ b/package/opentrons/opentrons-heater-shaker-firmware/opentrons-heater-shaker-firmware.hash
@@ -1,2 +1,2 @@
 # locally computed
-sha256 f61b5ac17778494113bcb5560f83cbb40ccb7abe0dc261d10a601f7f1c556c57  heater-shaker@v1.0.2.bin
+sha256 36fa3d45d35919974ec06d8c989d07bf89a61ace66f384d78ac7a0a7e55a01fd  heater-shaker@v1.0.3.bin

--- a/package/opentrons/opentrons-heater-shaker-firmware/opentrons-heater-shaker-firmware.mk
+++ b/package/opentrons/opentrons-heater-shaker-firmware/opentrons-heater-shaker-firmware.mk
@@ -4,8 +4,8 @@
 #
 ################################################################################
 
-OPENTRONS_HEATER_SHAKER_FIRMWARE_VERSION=v1.0.2
-OPENTRONS_HEATER_SHAKER_FIRMWARE_SOURCE=heater-shaker@v1.0.2.bin
+OPENTRONS_HEATER_SHAKER_FIRMWARE_VERSION=v1.0.3
+OPENTRONS_HEATER_SHAKER_FIRMWARE_SOURCE=heater-shaker@v1.0.3.bin
 OPENTRONS_HEATER_SHAKER_FIRMWARE_SITE=https://opentrons-modules-builds.s3.us-east-2.amazonaws.com/heater-shaker/$(OPENTRONS_HEATER_SHAKER_FIRMWARE_VERSION)
 OPENTRONS_HEATER_SHAKER_FIRMWARE_LICENSE=Apache-2.0
 


### PR DESCRIPTION
Updates from v1.0.2 to v1.0.3.

Tested uploading to a robot and confirmed that the app prompted an update to Heater Shaker firmware version V1.0.3. After the update, the version number reported from the Heater Shaker was V1.0.3.