### PR TITLE
board/opentrons/ot2: increase nginx request limit to 50M

### DIFF
--- a/board/opentrons/ot2/rootfs-overlay/etc/nginx/nginx.conf
+++ b/board/opentrons/ot2/rootfs-overlay/etc/nginx/nginx.conf
@@ -18,7 +18,7 @@ http {
 
         client_body_in_file_only off;
         client_body_buffer_size  128k;
-        client_max_body_size     2M;
+        client_max_body_size     50M;
 
         access_log /data/nginx-access.log;
 


### PR DESCRIPTION
Addresses [RSS-92](https://opentrons.atlassian.net/browse/RSS-92)

Valid protocols larger than 2M were failing because Nginx was configured to max request size of 2M