### PR TITLE
board/opentrons/ot2/config.txt: restore ttyAMA0 to uart0 so the robot-server can talk to the smoothie board.

### DIFF
--- a/board/opentrons/ot2/config.txt
+++ b/board/opentrons/ot2/config.txt
@@ -15,7 +15,8 @@ disable_overscan=1
 
 # fixes rpi (3B, 3B+, 3A+, 4B and Zero W) ttyAMA0 serial console
 enable_uart=1
-#dtoverlay=miniuart-bt	 # NOT WORKING
+dtoverlay=uart0,txd0_pin=14,rxd0_pin15
+dtoverlay=uart1,txd1_pin=32,rxd_pin33
 
 # How much memory in MB to assign to the GPU on Pi models having
 # 256, 512 or 1024 MB total memory

--- a/board/opentrons/ot2/config.txt
+++ b/board/opentrons/ot2/config.txt
@@ -16,7 +16,7 @@ disable_overscan=1
 # fixes rpi (3B, 3B+, 3A+, 4B and Zero W) ttyAMA0 serial console
 enable_uart=1
 dtoverlay=uart0,txd0_pin=14,rxd0_pin15
-dtoverlay=uart1,txd1_pin=32,rxd_pin33
+dtoverlay=uart1,txd1_pin=32,rxd1_pin33
 
 # How much memory in MB to assign to the GPU on Pi models having
 # 256, 512 or 1024 MB total memory


### PR DESCRIPTION
[RET-1240](https://opentrons.atlassian.net/browse/RET-1240)

**Overview**
Fixes an issue where the robot-server is not able to talk to the smoothie board.

**Breakdown**
We are using uart0 (GPIO pins 14, 15) to talk to the smoothie board, since usually bluetooth is mapped to uart0 we need the miniuart-bt overlay in the config to switch ttyAMA0 back to uart0. Unfortunately the miniuart-bt overlay does not work in this kernel version and causes a boot failure, without it we cant communicate with the smoothie board. So instead of using miniuart-bt lets just remap uart0 and uart1 using dtoverlay=uart0 to manually set the pins it should operate on.

**Changes**
- use dtoverlay=uart0 & uart1 to manually restore ttyAMA0 to uart0