### PR TITLE
build: update Dockerfile to track debian-slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stable-slim
+FROM debian:11-slim
 
 ARG filter_output
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,4 @@
-FROM debian:10-slim
-# We're stuck on Debian 10 (which will go EOL around 2022-08) because
-# Debian 11 upgrades GNU Make to v4.3, which breaks Buildroot's build system.
-#
-# Upstream Buildroot has fixes for this (try grepping their CHANGES file for
-# "4.3"), but those commits aren't currently in this fork.
+FROM debian:stable-slim
 
 ARG filter_output
 


### PR DESCRIPTION
[RET-1177](https://opentrons.atlassian.net/browse/RET-1177)

Debian 10 has reached EOL, update to debian-slim to track the latest stable (currently Debian 11)

[RET-1177]: https://opentrons.atlassian.net/browse/RET-1177?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ