### PR TITLE
board/opentrons/ot2: add pypi.opentrons.com

### DIFF
--- a/board/opentrons/ot2/rootfs-overlay/etc/pip.conf
+++ b/board/opentrons/ot2/rootfs-overlay/etc/pip.conf
@@ -1,2 +1,3 @@
 [install]
 root = /var/user-packages
+extra_index_url = https://pypi.opentrons.com/simple/

--- a/board/opentrons/ot2/rootfs-overlay/usr/lib/python3.10/site-packages/user-packages.pth
+++ b/board/opentrons/ot2/rootfs-overlay/usr/lib/python3.10/site-packages/user-packages.pth
@@ -1,2 +1,2 @@
 # Add the path to the rw package directory in /var
-/var/user-packages/usr/lib/python3.7/site-packages/
+/var/user-packages/usr/lib/python3.10/site-packages/


### PR DESCRIPTION
Pip needs to look at pypi.opentrons.com for binary packages.