### PR TITLE
board/opentrons/ot2: Add robot_model flag to VERSION.json file

### DIFF
--- a/board/opentrons/ot2/write_version.py
+++ b/board/opentrons/ot2/write_version.py
@@ -50,7 +50,7 @@ version_dict = {'buildroot_version': br_version,
                 'buildroot_branch': br_branch,
                 'buildroot_buildid': build_id,
                 'build_type': os.getenv('OT_BUILD_TYPE', 'unknown/dev'),
-                'robotModel': os.getenv('ROBOT_MODEL', 'OT-2 Standard')}
+                'robot_model': os.getenv('ROBOT_MODEL', 'OT-2 Standard')}
 
 for f in args.in_versions:
     version_dict.update(json.load(f))

--- a/board/opentrons/ot2/write_version.py
+++ b/board/opentrons/ot2/write_version.py
@@ -49,7 +49,8 @@ version_dict = {'buildroot_version': br_version,
                 'buildroot_sha': br_sha,
                 'buildroot_branch': br_branch,
                 'buildroot_buildid': build_id,
-                'build_type': os.getenv('OT_BUILD_TYPE', 'unknown/dev')}
+                'build_type': os.getenv('OT_BUILD_TYPE', 'unknown/dev'),
+                'robotModel': os.getenv('ROBOT_MODEL', 'OT-2 Standard')}
 
 for f in args.in_versions:
     version_dict.update(json.load(f))

--- a/board/opentrons/ot2/write_version.py
+++ b/board/opentrons/ot2/write_version.py
@@ -50,7 +50,7 @@ version_dict = {'buildroot_version': br_version,
                 'buildroot_branch': br_branch,
                 'buildroot_buildid': build_id,
                 'build_type': os.getenv('OT_BUILD_TYPE', 'unknown/dev'),
-                'robot_model': os.getenv('ROBOT_MODEL', 'OT-2 Standard')}
+                'robot_type': os.getenv('ROBOT_TYPE', 'OT-2 Standard')}
 
 for f in args.in_versions:
     version_dict.update(json.load(f))


### PR DESCRIPTION
[RCORE-320](https://opentrons.atlassian.net/browse/RCORE-320)

**Description**
- The update server needs to validate the update zip file it receives, since we now also have an ot3 build we need to make sure the build is for the corresponding device by comparing the 'robot_model' flag.

**Changes**
- add 'robot_type' flag for OT2 to the VERSION.json file