### PR TITLE
build: store build container on GHCR

### DIFF
--- a/.github/workflows/update-container.yaml
+++ b/.github/workflows/update-container.yaml
@@ -1,0 +1,27 @@
+on:
+  push:
+    tags:
+      - "*"
+    # change this before merging - just need to test since workflow_dispatch
+    # only works once merged
+    branches:
+      - "*"
+  workflow_dispatch:
+
+jobs:
+  container-build-push:
+    runs-on: 'ubuntu-latest'
+    permissions:
+      packages: write
+      contents: read
+    steps:
+      - uses: 'actions/checkout@v3'
+      - name: 'Build the container'
+        id: container-build
+        run: |
+          ./opentrons-build-container.sh build
+      - name: 'Deploy the container'
+        id: container-deploy
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin
+          ./opentrons-build-container.sh push

--- a/.github/workflows/update-container.yaml
+++ b/.github/workflows/update-container.yaml
@@ -2,9 +2,7 @@ on:
   push:
     tags:
       - "*"
-    # change this before merging - just need to test since workflow_dispatch
-    # only works once merged
-    branches:
+    branches_ignore:
       - "*"
   workflow_dispatch:
 

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -8,9 +8,6 @@ env:
     DATADOG_API_KEY: /buildroot-codebuild/datadog-api
 
 phases:
-  pre_build:
-    commands:
-      - "docker build -t opentrons-buildroot ."
   build:
     commands:
       - ./opentrons-build.sh

--- a/in_docker.sh
+++ b/in_docker.sh
@@ -36,10 +36,5 @@ if [[ -n "${FILTER}" ]]; then
    done;
 fi
 
-if [[ -z "${filter}" ]]; then
-    echo "Unfiltered make"
-    BR2_EXTERNAL=/opentrons make -C /buildroot $@
-else
-    echo "Filtered make"
-    BR2_EXTERNAL=/opentrons make -C /buildroot $@ 2>${filtered_warnings_log} | awk "/^make/;{print $0 >>\"${filtered_build_log}\"}"
-fi
+echo "Unfiltered make"
+BR2_EXTERNAL=/opentrons make -C /buildroot $@

--- a/opentrons-build-container.sh
+++ b/opentrons-build-container.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+
+# Utilities for the opentrons build container.
+
+
+if [[ -n "${CI}" ]]; then
+   filter_arg="--build-arg filter_output=true"
+fi
+
+githubname="$(git describe --all --dirty --always | tr '[:upper:]' '[:lower:]')"
+imgname=ghcr.io/opentrons/buildroot
+noheads=${githubname/heads//}
+imgtag=${noheads:2}
+
+
+
+help () {
+    cat <<EOF
+$0: Utilities for opentrons build container. Argument is a single word:
+   $0 build: build a container locally and return its name
+   $0 push: push a container. It will be the last one built.
+   $0 build-push: build a container then push it.
+   $0 pull: pull the latest container for running
+EOF
+    exit 1
+}
+
+build () {
+    docker build ${filter_arg} -t ${imgname}:${imgtag} -t ${imgname}:latest . 1>&2 || exit 1
+    echo ${imgname}:${imgtag}
+}
+
+push () {
+    docker push ${imgname}:latest 1>&2 || exit 1
+    echo ${imgname}:latest
+}
+
+pull () {
+    docker pull ${imgname}:latest 1>&2 || exit 1
+    echo ${imgname}:latest
+}
+
+
+case $# in
+    0)
+        help
+        ;;
+    *)
+        case $1 in
+            build)
+                build && exit 0
+            ;;
+            push)
+                push && exit 0
+            ;;
+            build-push)
+                build && push && exit 0
+            ;;
+            pull)
+                pull && exit 0
+            ;;
+            *)
+                help
+                ;;
+        esac
+esac

--- a/opentrons-build.sh
+++ b/opentrons-build.sh
@@ -33,18 +33,12 @@ DOCKER_BIND="${DOCKER_BIND_BR} ${DOCKER_BIND_OT}"
 heads=${@:1:$(($# - 1))}
 tail=${@:$#}
 
-if [[ -n "${CI}" ]]; then
-   filter_arg="--build-arg filter_output=true"
-fi
-
 if [[ -z "${DATADOG_API_KEY}" ]]; then
     export DATADOG_API_KEY=$(./get_parameter.py /buildroot-codebuild/datadog-api -)
 fi
 
-githubname="$(git describe --all --dirty --always | tr '[:upper:]' '[:lower:]')"
-imgname=opentrons-buildroot-${githubname}
 
-docker build ${filter_arg} -t ${imgname} .
+imgname=$(./opentrons-build-container.sh pull || ./opentrons-build-container.sh build)
 
 # Save codebuild-relevant env vars to get them inside docker
 env | grep 'CODEBUILD\|AWS\|DATADOG' > .env


### PR DESCRIPTION
We consistently (and reasonably) get limited by dockerhub when we build, because we're pulling from dockerhub every single time we build.

Instead put our build container - which essentially never changes
- on github container repo as a public package, so we stop hitting dockerhub every time.

Split out container build management into another bash script that can build, push and pull; use it in our build script to pull if possible and build if not; add a workflow to autodeploy on tag and manually.