### PR TITLE
board/opentrons/ot2: remove nginx request size limit for /protocols endpoint to accommodate larger protocols.

### DIFF
--- a/board/opentrons/ot2/rootfs-overlay/etc/nginx/nginx.conf
+++ b/board/opentrons/ot2/rootfs-overlay/etc/nginx/nginx.conf
@@ -34,6 +34,18 @@ http {
             proxy_set_header         Connection "upgrade";
         }
 
+        location /protocols {
+            proxy_http_version       1.1;
+            proxy_read_timeout       1h;
+            proxy_pass               http://unix:/run/aiohttp.sock;
+
+            # Proxying these hop-by-hop headers is necessary for WebSockets.
+            proxy_set_header         Upgrade $http_upgrade;
+            proxy_set_header         Connection "upgrade";
+            # need for uploading large protocols
+            client_max_body_size     50M;
+        }
+
         location /server {
             proxy_http_version       1.1;
             proxy_read_timeout       1h;

--- a/board/opentrons/ot2/rootfs-overlay/etc/nginx/nginx.conf
+++ b/board/opentrons/ot2/rootfs-overlay/etc/nginx/nginx.conf
@@ -43,7 +43,7 @@ http {
             proxy_set_header         Upgrade $http_upgrade;
             proxy_set_header         Connection "upgrade";
             # need for uploading large protocols
-            client_max_body_size     50M;
+            client_max_body_size     0;
         }
 
         location /server {


### PR DESCRIPTION
closes [RSS-92](https://opentrons.atlassian.net/browse/RSS-92)

Valid protocols larger than 2M were failing because Nginx was configured to max request size of 2M so increase the max request limit for the /protocols endpoint to 50MB.