### PR TITLE
fix(recipes-robot): we should not set proxy headers for the /protocols endpoint in nginx conf

### DIFF
--- a/board/opentrons/ot2/rootfs-overlay/etc/nginx/nginx.conf
+++ b/board/opentrons/ot2/rootfs-overlay/etc/nginx/nginx.conf
@@ -39,9 +39,6 @@ http {
             proxy_read_timeout       1h;
             proxy_pass               http://unix:/run/aiohttp.sock;
 
-            # Proxying these hop-by-hop headers is necessary for WebSockets.
-            proxy_set_header         Upgrade $http_upgrade;
-            proxy_set_header         Connection "upgrade";
             # need for uploading large protocols
             client_max_body_size     0;
         }


### PR DESCRIPTION

# Overview
Dont set proxy headers for /protocols endpoint [(RSS-166)](https://opentrons.atlassian.net/browse/RSS-166)

# Changelog

- Remove proxy_set_header for /protocol endpoint

# Review requests

- [x] make sure we can send protocols to the ot2
- [x] make sure we can send large (>3MB) protocols to the ot2

# Risk Assessment
low 