### PR TITLE
/board/opentrons/ot2: add nginx config to route to system server.

### DIFF
--- a/board/opentrons/ot2/rootfs-overlay/etc/nginx/nginx.conf
+++ b/board/opentrons/ot2/rootfs-overlay/etc/nginx/nginx.conf
@@ -32,6 +32,22 @@ http {
             # Proxying these hop-by-hop headers is necessary for WebSockets.
             proxy_set_header         Upgrade $http_upgrade;
             proxy_set_header         Connection "upgrade";
+
+            # /system must be defined as a nested child of /, otherwise it will
+            # conflict with matches to /system/time.
+            location /system {
+                proxy_http_version       1.1;
+                proxy_read_timeout       1h;
+                proxy_pass               http://127.0.0.1:32950;
+            }
+
+            # The /system/time endpoints live in the robot server, and thus
+            # the configuration here has to match the / config
+            location /system/time {
+                proxy_http_version       1.1;
+                proxy_read_timeout       1h;
+                proxy_pass               http://unix:/run/aiohttp.sock;
+            }
         }
 
         location /protocols {
@@ -50,24 +66,6 @@ http {
             proxy_pass               http://127.0.0.1:34000;
             proxy_request_buffering  off;
             client_max_body_size     0;  # Unlimited to allow large update files.
-        }
-
-        location /system {
-            proxy_http_version       1.1;
-            proxy_read_timeout       1h;
-            proxy_pass               http://127.0.0.1:32950;
-        }
-
-        # The /system/time endpoints live in the robot server, and thus
-        # the configuration here has to match the / config
-        location /system/time {
-            proxy_http_version       1.1;
-            proxy_read_timeout       1h;
-            proxy_pass               http://unix:/run/aiohttp.sock;
-
-            # Proxying these hop-by-hop headers is necessary for WebSockets.
-            proxy_set_header         Upgrade $http_upgrade;
-            proxy_set_header         Connection "upgrade";
         }
     }
 }

--- a/board/opentrons/ot2/rootfs-overlay/etc/nginx/nginx.conf
+++ b/board/opentrons/ot2/rootfs-overlay/etc/nginx/nginx.conf
@@ -51,5 +51,23 @@ http {
             proxy_request_buffering  off;
             client_max_body_size     0;  # Unlimited to allow large update files.
         }
+
+        location /system {
+            proxy_http_version       1.1;
+            proxy_read_timeout       1h;
+            proxy_pass               http://127.0.0.1:32950;
+        }
+
+        # The /system/time endpoints live in the robot server, and thus
+        # the configuration here has to match the / config
+        location /system/time {
+            proxy_http_version       1.1;
+            proxy_read_timeout       1h;
+            proxy_pass               http://unix:/run/aiohttp.sock;
+
+            # Proxying these hop-by-hop headers is necessary for WebSockets.
+            proxy_set_header         Upgrade $http_upgrade;
+            proxy_set_header         Connection "upgrade";
+        }
     }
 }


### PR DESCRIPTION
This PR adds configuration to NGINX to allow external access to the system server.

Also adds an explicit config to route `/system/time` to the robot server, as that endpoint is not ported to the system server yet.

Tested by uploading the edited `nginx.conf` to a robot and running `nginx -s reload`, and also uploading the system server changes from https://github.com/Opentrons/opentrons/pull/12278.

* I was able to go to {robot_url}:31950/system/docs and interact with the endpoints on the system server without issue.
* I was also about to go to {robot_url}:31950/docs and interact with GET /system/time without issue.

I don't want to merge this until 6.3.0 is released in case we have to make any other buildroot changes.