### PR TITLE
chore: correct builds on github actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -134,7 +134,8 @@ jobs:
         id: 'upload-results'
         run: |
           pushd ${{steps.cache-setup.outputs.output}}
-          aws --profile=${{ steps.aws.outputs.profile_name }} s3 cp --acl=public-read ./* s3://${S3_ARTIFACT_ARN/arn:aws:s3:::/}/ot2-br/${{github.run_id}}
+          aws --profile=${{ steps.aws.outputs.profile_name }} s3 cp --recursive --acl=public-read ./images/ s3://${S3_ARTIFACT_ARN/arn:aws:s3:::/}/ot2-br/${{github.run_id}}/
+
           root_url=https://${S3_ARTIFACT_ARN/arn:aws:s3:::/}/ot2-br/${{github.run_id}}
           echo "console_url=https://s3.console.aws.amazon.com/s3/buckets/${S3_ARTIFACT_ARN/arn:aws:s3::::/}?prefix=${{github.run_id}}" >> $GITHUB_OUTPUT
           echo "version_file_url=$root_url/VERSION.json" >> $GITHUB_OUTPUT

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,8 +34,9 @@ jobs:
     steps:
       - name: Set up vm requirements
         run: |
-          echo "fs.inotify.max_user_watches=1048576" >> /etc/sysctl.conf
-          echo "fs.file-max=100000" >> /etc/sysctl.conf
+          echo 'fs.inotify.max_user_watches=655360' | tee -a /etc/sysctl.conf
+          echo 'fs.inotify.max_user_instances=1280' | tee -a /etc/sysctl.conf
+          echo 'fs.file-max=100000' | tee -a /etc/sysctl.conf
           sysctl -p
       - name: Fetch initial sources for action
         uses: 'actions/checkout@v3'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,9 +8,9 @@ on:
           Ref of https://github.com/opentrons/opentrons to build. This MUST be a full ref, e.g. refs/heads/edge, or '-' to indicate not-specified. If not specified, will be determined from the oe-core ref if specified, and then default to edge.
         required: true
         default: '-'
-      oe-core-ref:
+      buildroot-ref:
         description: |
-          Ref of https://github.com/opentrons/oe-core to build. This is different from the ref specified in the github api/webUI when starting this workflow - that ref is what contains this workflow, this ref specifies what gets built. It MUST be a full ref, e.g. refs/heads/main, or '-' to indicate not-specified. If not specified, will be decided based on the monorepo ref; if that isn't specified, will be main.
+          Ref of https://github.com/opentrons/buildroot to build. This is different from the ref specified in the github api/webUI when starting this workflow - that ref is what contains this workflow, this ref specifies what gets built. It MUST be a full ref, e.g. refs/heads/main, or '-' to indicate not-specified. If not specified, will be decided based on the monorepo ref; if that isn't specified, will be main.
         required: true
         default: '-'
       infra-stage:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -123,6 +123,12 @@ jobs:
         run: |
           cd buildroot
           docker run ${{steps.docker-args.outputs.args}} all
+      - name: Upload build log result
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: buildlog.txt
+          path: ./buildroot/buildlog.txt
       - name: Upload results to S3
         shell: bash
         id: 'upload-results'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,14 +65,50 @@ jobs:
           secret_access_key: ${{ secrets.ROBOT_STACK_AWS_SECRET_ACCESS_KEY }}
           region: us-east-2
           stage: ${{ matrix.build_env }}
+      - name: Set up docker environment file
+        id: docker-env
+        run: |
+          cat <<EOF >./docker-envfile
+          OT_BUILD_TYPE=${{steps.build-refs.outputs.build-type}}
+          FORCE_UNSAFE_CONFIGURE=1
+          BR2_DL_DIR=/downloads
+          EOF
+          echo "envfile=$(pwd)/docker-envfile" >> $GITHUB_OUTPUT
+
+      - name: Build or download docker container
+        id: get-image
+        run: |
+          cd buildroot
+          imgname=$(./opentrons-build-container.sh pull || ./opentrons-build-container.sh build)
+          echo "image-name=$imagename" >> $GITHUB_OUTPUT
+
+      - name: Set up docker args
+        id: docker-args
+        run: |
+          cachedir=${LOCAL_CACHE:-./cache}
+          mount_args="type=bind,consistency=delegated"
+          bind_br="--mount source=$(pwd)/buildroot,destination=/buildroot,${mount_args}"
+          bind_ot="--mount source=$(pwd)/opentrons,destination=/opentrons,${mount_args}"
+          bind_dl="--mount source=${cachedir}/downloads,destination=/downloads,${mount_args}"
+          bind_op="--mount source=${cachedir}/outputs,destination=/outputs,${mount_args}"
+          binds="${bind_br} ${bind_ot} ${bind_dl} ${bind_op}"
+          env="--env-file ${{steps.docker-env.outputs.envfile}}"
+          echo "run-binds=${binds}" >> $GITHUB_OUTPUT
+          echo "env=${env}" >> $GITHUB_OUTPUT
+          args="${binds} ${env} ${{steps.get-image.outputs.image-name}} O=/outputs"
+          echo "args=${args}" >> $GITHUB_OUTPUT
+      - name: Configure
+        run: |
+          cd buildroot
+          docker run ${{steps.docker-args.outputs.args}} ot2_defconfig
+      - name: Download package sources
+        run: |
+          cd buildroot
+          docker run ${{steps.docker-args.outputs.args}} source
       - name: Run build
         run: |
           cd buildroot
-          ./opentrons-build.sh
-
-      - name: Prune docker images
-        if: always()
-        run: docker image prune -af
+          docker run ${{steps.docker-args.outputs.args}} all
       - name: Upload results to S3
         shell: bash
         id: 'upload-results'
@@ -90,3 +126,4 @@ jobs:
         if: always()
         run: |
           rm -rf ./*
+          rm -rf ${LOCAL_CACHE:-./cache}/outputs

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,6 +65,15 @@ jobs:
           secret_access_key: ${{ secrets.ROBOT_STACK_AWS_SECRET_ACCESS_KEY }}
           region: us-east-2
           stage: ${{ matrix.build_env }}
+
+      - name: Pull or create cache locations
+        id: cache-setup
+        run: |
+          cachedir=${LOCAL_CACHE:-./cache}
+          for cachetype in downloads output ; do
+            mkdir -p ${cachedir}/${cachetype}
+            echo "${cachetype}=${cachedir}/${cachetype}" >> $GITHUB_OUTPUT
+          done
       - name: Set up docker environment file
         id: docker-env
         run: |
@@ -85,17 +94,16 @@ jobs:
       - name: Set up docker args
         id: docker-args
         run: |
-          cachedir=${LOCAL_CACHE:-./cache}
           mount_args="type=bind,consistency=delegated"
           bind_br="--mount source=$(pwd)/buildroot,destination=/buildroot,${mount_args}"
           bind_ot="--mount source=$(pwd)/opentrons,destination=/opentrons,${mount_args}"
-          bind_dl="--mount source=${cachedir}/downloads,destination=/downloads,${mount_args}"
-          bind_op="--mount source=${cachedir}/outputs,destination=/outputs,${mount_args}"
+          bind_dl="--mount source=${{steps.cache-setup.outputs.downloads}},destination=/downloads,${mount_args}"
+          bind_op="--mount source=${{steps.cache-setup.outputs.output}},destination=/output,${mount_args}"
           binds="${bind_br} ${bind_ot} ${bind_dl} ${bind_op}"
           env="--env-file ${{steps.docker-env.outputs.envfile}}"
           echo "run-binds=${binds}" >> $GITHUB_OUTPUT
           echo "env=${env}" >> $GITHUB_OUTPUT
-          args="${binds} ${env} ${{steps.get-image.outputs.image-name}} O=/outputs"
+          args="${binds} ${env} ${{steps.get-image.outputs.image-name}} O=/output"
           echo "args=${args}" >> $GITHUB_OUTPUT
       - name: Configure
         run: |
@@ -113,7 +121,7 @@ jobs:
         shell: bash
         id: 'upload-results'
         run: |
-          pushd buildroot/output/images/
+          pushd ${{steps.cache-setup.outputs.output}}
           aws --profile=${{ steps.aws.outputs.profile_name }} s3 cp --acl=public-read ./* s3://${S3_ARTIFACT_ARN/arn:aws:s3:::/}/ot2-br/${{github.run_id}}
           root_url=https://${S3_ARTIFACT_ARN/arn:aws:s3:::/}/ot2-br/${{github.run_id}}
           echo "console_url=https://s3.console.aws.amazon.com/s3/buckets/${S3_ARTIFACT_ARN/arn:aws:s3::::/}?prefix=${{github.run_id}}" >> $GITHUB_OUTPUT
@@ -126,4 +134,5 @@ jobs:
         if: always()
         run: |
           rm -rf ./*
-          rm -rf ${LOCAL_CACHE:-./cache}/outputs
+          output_check=${{steps.cache-setup.outputs.output}}
+          rm -rf ${output_check:-/does/not/exist}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,11 @@ jobs:
     timeout-minutes: 480
     runs-on: ['self-hosted', '${{matrix.build_env}}']
     steps:
+      - name: Set up vm requirements
+        run: |
+          echo "fs.inotify.max_user_watches=1048576" >> /etc/sysctl.conf
+          echo "fs.file-max=100000" >> /etc/sysctl.conf
+          sysctl -p
       - name: Fetch initial sources for action
         uses: 'actions/checkout@v3'
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,7 +80,7 @@ jobs:
         run: |
           cd buildroot
           imgname=$(./opentrons-build-container.sh pull || ./opentrons-build-container.sh build)
-          echo "image-name=$imagename" >> $GITHUB_OUTPUT
+          echo "image-name=$imgname" >> $GITHUB_OUTPUT
 
       - name: Set up docker args
         id: docker-args

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,9 +22,6 @@ on:
           - 'stage-prod'
           - 'stage-dev'
         default: 'stage-prod'
-  push:
-    branches:
-      - '*'
 
 jobs:
   run-build:

--- a/board/opentrons/ot2/post-build.sh
+++ b/board/opentrons/ot2/post-build.sh
@@ -82,6 +82,10 @@ ln -s /var/lib/dropbear ${TARGET_DIR}/etc/dropbear
 # Syslog-ng extra setup:
 # - install the datadog api key
 
+if [ -z ${DATADOG_API_KEY+x} ] ; then
+    printf "Datadog API key is unknown, build will not be capable of upstreaming logs" >&2
+    DATADOG_API_KEY=""
+fi
 echo "@define datadog_api_key \"${DATADOG_API_KEY}\"" > ${TARGET_DIR}/etc/syslog-ng/api_key.conf
 mkdir -p ${TARGET_DIR}/etc/syslog-ng/certs.d/
 rm -rf ${TARGET_DIR}/etc/syslog-ng/certs.d/*

--- a/in_docker.sh
+++ b/in_docker.sh
@@ -32,5 +32,5 @@ if [[ -z "${filter}" ]]; then
     BR2_EXTERNAL=/opentrons make -C /buildroot "$@"
 else
     echo "Filtered make"
-    BR2_EXTERNAL=/opentrons make -C /buildroot "$@" 2> >(tee -a ${filtered_build_log}) | awk "/^make/;{print $0 >>\"${filtered_build_log}\"}"
+    BR2_EXTERNAL=/opentrons make -C /buildroot "$@" 2> >(tee -a ${filtered_build_log}) > ${filtered_build_log}
 fi

--- a/in_docker.sh
+++ b/in_docker.sh
@@ -7,17 +7,8 @@ set -o pipefail
 set -e
 set -v
 
-targets=$@
 filtered_build_log="/buildroot/buildlog.txt"
-filtered_warnings_log="/buildroot/warnings.txt"
 
-function finish {
-    if [[ -f "${filtered_warnings_log}" ]]; then
-        cat ${filtered_warnings_log}
-    fi
-}
-
-trap finish EXIT
 
 if [[ -n "${FILTER}" ]]; then
    echo "in ci"
@@ -36,5 +27,10 @@ if [[ -n "${FILTER}" ]]; then
    done;
 fi
 
-echo "Unfiltered make"
-BR2_EXTERNAL=/opentrons make -C /buildroot $@
+if [[ -z "${filter}" ]]; then
+    echo "Unfiltered make"
+    BR2_EXTERNAL=/opentrons make -C /buildroot "$@"
+else
+    echo "Filtered make"
+    BR2_EXTERNAL=/opentrons make -C /buildroot "$@" 2> >(tee -a ${filtered_build_log}) | awk "/^make/;{print $0 >>\"${filtered_build_log}\"}"
+fi


### PR DESCRIPTION
These builds now build everything, which is good, but do not yet have access to the signing process or to the datadog log upstreaming API key. The next step is to handle those, but right now we can build and emplace build artifacts.