### PR TITLE
chore: fix release url handling

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -210,16 +210,16 @@ jobs:
           echo "root_uri=$root_uri" >> $GITHUB_OUTPUT
           echo "root_url=$root_url" >> $GITHUB_OUTPUT
           echo "root_prefix=ot2-br" >> $GITHUB_OUTPUT
+          echo "machine_root=${arnslug}/${prefix}" >> $GITHUB_OUTPUT
           popd
       - name: Handle release manifest
         if: ${{ steps.build-refs.outputs.build-type == 'release' }}
         shell: bash
         run: |
           pushd buildroot
-          base_url=s3://${{steps.upload-results.outputs.arnslug}}/${{steps.upload-results.outputs.root_prefix}}
-          aws --profile=${{ steps.aws.outputs.profile_name }} s3 cp --acl=public-read ${base_url}/releases.json releases.json
-          python3 update_releases_file.py --releases-file releases.json --version-file ${{steps.artifact-copy.outputs.version_json}} --base-url $base_url
-          aws --profile=${{ steps.aws.outputs.profile_name }} s3 cp --acl=public-read releases.json ${base_url}/releases.json
+          aws --profile=${{ steps.aws.outputs.profile_name }} s3 cp --acl=public-read ${{steps.upload-results.output.machine_root}}/releases.json releases.json
+          python3 update_releases_file.py --releases-file releases.json --version-file ${{steps.artifact-copy.outputs.version_json}} --base-url ${{ steps.upload-results.output.root_url }}
+          aws --profile=${{ steps.aws.outputs.profile_name }} s3 cp --acl=public-read releases.json ${{steps.upload-results.output.machine_root}}/releases.json
           popd
 
       - name: Upload system zip to monorepo release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -217,9 +217,9 @@ jobs:
         shell: bash
         run: |
           pushd buildroot
-          aws --profile=${{ steps.aws.outputs.profile_name }} s3 cp --acl=public-read ${{steps.upload-results.output.machine_root}}/releases.json releases.json
-          python3 update_releases_file.py --releases-file releases.json --version-file ${{steps.artifact-copy.outputs.version_json}} --base-url ${{ steps.upload-results.output.root_url }}
-          aws --profile=${{ steps.aws.outputs.profile_name }} s3 cp --acl=public-read releases.json ${{steps.upload-results.output.machine_root}}/releases.json
+          aws --profile=${{ steps.aws.outputs.profile_name }} s3 cp --acl=public-read ${{steps.upload-results.outputs.machine_root}}/releases.json releases.json
+          python3 update_releases_file.py --releases-file releases.json --version-file ${{steps.artifact-copy.outputs.version_json}} --base-url ${{ steps.upload-results.outputs.root_url }}
+          aws --profile=${{ steps.aws.outputs.profile_name }} s3 cp --acl=public-read releases.json ${{steps.upload-results.outputs.machine_root}}/releases.json
           popd
 
       - name: Upload system zip to monorepo release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -182,7 +182,7 @@ jobs:
           cp ${artifact_dir}/ot2-fullimage.zip ${versioned_artifact_dir}/${versioned_fullimage_zip}
           echo "ot2_fullimage_versioned=${versioned_artifact_dir}/${versioned_fullimage_zip}" >> $GITHUB_OUTPUT
 
-          versioned_version_json="VERSION-${_vers_tag}.json"
+          versioned_version_json="VERSION-ot2-${_vers_tag}.json"
           cp ${artifact_dir}/VERSION.json ${versioned_artifact_dir}/${versioned_version_json}
           echo "version_json_versioned=${versioned_artifact_dir}/${versioned_version_json}" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -217,9 +217,9 @@ jobs:
         shell: bash
         run: |
           pushd buildroot
-          aws --profile=${{ steps.aws.outputs.profile_name }} s3 cp --acl=public-read ${{steps.upload-results.outputs.machine_root}}/releases.json releases.json
+          aws --profile=${{ steps.aws.outputs.profile_name }} s3 cp --acl=public-read s3://${{steps.upload-results.outputs.machine_root}}/releases.json releases.json
           python3 update_releases_file.py --releases-file releases.json --version-file ${{steps.artifact-copy.outputs.version_json}} --base-url ${{ steps.upload-results.outputs.root_url }}
-          aws --profile=${{ steps.aws.outputs.profile_name }} s3 cp --acl=public-read releases.json ${{steps.upload-results.outputs.machine_root}}/releases.json
+          aws --profile=${{ steps.aws.outputs.profile_name }} s3 cp --acl=public-read releases.json s3://${{steps.upload-results.outputs.machine_root}}/releases.json
           popd
 
       - name: Upload system zip to monorepo release


### PR DESCRIPTION
We were uploading to a key in the releases url that was the s3 uri of the ot2 section of the bucket which just plain isn't right.