### PR TITLE
fix: allow docker build to handle newer versions of git

### DIFF
--- a/in_docker.sh
+++ b/in_docker.sh
@@ -27,6 +27,8 @@ if [[ -n "${FILTER}" ]]; then
    done;
 fi
 
+git config --global --add safe.directory /opentrons
+
 if [[ -z "${filter}" ]]; then
     echo "Unfiltered make"
     LANG="en_US.UTF-8" BR2_EXTERNAL=/opentrons make -C /buildroot "$@"


### PR DESCRIPTION
This fixes a fatal error in building the image:
Without flagging that the directory is "safe" the following error prevents the python-opentrons-*-version.json from being generated

fatal: detected dubious ownership in repository at '/opentrons'
