### PR TITLE
fix: add /buildroot to the safe directories 

### DIFF
--- a/in_docker.sh
+++ b/in_docker.sh
@@ -28,6 +28,7 @@ if [[ -n "${FILTER}" ]]; then
 fi
 
 git config --global --add safe.directory /opentrons
+git config --global --add safe.directory /buildroot
 
 if [[ -z "${filter}" ]]; then
     echo "Unfiltered make"


### PR DESCRIPTION
so git can correctly generate the versions when doing the target build/package step