### PR TITLE
fix(build): Do not remove README_STARTUP file required by IPython.

### DIFF
--- a/board/opentrons/ot2/post-build.sh
+++ b/board/opentrons/ot2/post-build.sh
@@ -78,6 +78,9 @@ cp ${BINARIES_DIR}/VERSION.json ${TARGET_DIR}/etc/VERSION.json
 rm -f ${TARGET_DIR}/etc/dropbear
 ln -s /var/lib/dropbear ${TARGET_DIR}/etc/dropbear
 
+# Remove tests and README
+# NOTE: DO NOT REMOVE 'README_STARTUP' as this is required by IPython and
+# causes jupyter-notebook to not work without it.
 find ${TARGET_DIR}/usr/lib/ -name tests -or -name test | xargs --verbose rm -rf
-find ${TARGET_DIR} -type f -iname 'README*' | xargs --verbose rm -rf
+find ${TARGET_DIR} -type f -iname 'README*' ! -name 'README_STARTUP' | xargs --verbose rm -rf
 rm -rf ${TARGET_DIR}/usr/share/doc


### PR DESCRIPTION
To save space on the OT-2 builds we remove tests and readme files in the post-build step which is great, unfortunately, IPython does not work without its 'README_STARTUP' file which we also removed. So Lets exclude this file when cleaning up.

Closes: [RQA-2412](https://opentrons.atlassian.net/browse/RQA-2412)

# Test plan

- [x] Create an OT-2 build and make sure we can run Jupyter Notebook and run protocols

# Log Changes

- Exclude the README_STARTUP file when cleaning out tests and readme files

[RQA-2412]: https://opentrons.atlassian.net/browse/RQA-2412?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ