### PR TITLE
package/python-notebook: upgrade notebook to 6.0.3

### DIFF
--- a/package/python-notebook/python-notebook.hash
+++ b/package/python-notebook/python-notebook.hash
@@ -1,3 +1,3 @@
 # md5, sha256 from https://pypi.org/pypi/notebook/json
-md5	fdea9acce79d1d4c49e628cee9058525  notebook-5.7.4.tar.gz
-sha256	d908673a4010787625c8952e91a22adf737db031f2aa0793ad92f6558918a74a  notebook-5.7.4.tar.gz
+md5	9714add6d588c5327c4f5029d7c94f7b  notebook-6.0.3.tar.gz
+sha256	47a9092975c9e7965ada00b9a20f0cf637d001db60d241d479f53c0be117ad48  notebook-6.0.3.tar.gz

--- a/package/python-notebook/python-notebook.mk
+++ b/package/python-notebook/python-notebook.mk
@@ -4,9 +4,9 @@
 #
 ################################################################################
 
-PYTHON_NOTEBOOK_VERSION = 5.7.4
+PYTHON_NOTEBOOK_VERSION = 6.0.3
 PYTHON_NOTEBOOK_SOURCE = notebook-$(PYTHON_NOTEBOOK_VERSION).tar.gz
-PYTHON_NOTEBOOK_SITE = https://files.pythonhosted.org/packages/6e/22/b5dcce67559d63d0f22e46d806305710808c698a1b91c07eb09e389785e0
+PYTHON_NOTEBOOK_SITE = https://files.pythonhosted.org/packages/a9/c8/77ab314f1a0102c50762efcc2b58be99780ddffb88bcd5820e2715e1799e
 PYTHON_NOTEBOOK_SETUP_TYPE = setuptools
 PYTHON_NOTEBOOK_LICENSE = BSD-3-Clause
 


### PR DESCRIPTION
Jupyter Notebook was not working  so it needed to be updated from 5.7.4 -> 6.0.3

Closes: [RQA-2412](https://opentrons.atlassian.net/browse/RQA-2412)

# Test Plan

- [x] Open up a Jupyter Notebook instance from the Opentrons app
- [x] Create a new notebook and make sure we can run basic Python commands like print(1)
- [x] Make sure we can import opentrons packages like `import opentrons.execute`
- [x] Make sure we can create a simple protocol context with `protocol = opentrons.execute.get_protocol_api('2.15')`
- [x] Make sure we can home the gantry `protocol.home()`
- [x] Make sure we can turn the rail lights on/off `protocol.set_rail_lights(True)` and `protocol.set_rail_lights(False)`

See Screenshot
<img width="1149" alt="Screen Shot 2024-03-01 at 6 01 16 PM" src="https://github.com/Opentrons/buildroot/assets/12740774/2699d467-1bea-4768-8edd-c8b5fe66c53c">


[RQA-2412]: https://opentrons.atlassian.net/browse/RQA-2412?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ