### PR TITLE
chore(build): add concurrency to the github workflow to conditionally queue builds.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,6 +56,9 @@ jobs:
     name: 'Building ${{needs.decide-refs.outputs.variant}} images on ${{ matrix.build_env }}'
     timeout-minutes: 480
     runs-on: ['self-hosted', '${{matrix.build_env}}', '${{needs.decide-refs.outputs.variant}}']
+    concurrency:
+      group: ${{needs.decide-refs.outputs.monorepo}} ${{needs.decide-refs.outputs.buildroot}} ${{needs.decide-refs.outputs.variant}} ${{needs.decide-refs.outputs.build-type}} ${{inputs.infra-stage}}
+      cancel-in-progress: false
     steps:
       - name: Set up vm requirements
         run: |


### PR DESCRIPTION
# Overview

Closes: [PLAT-309](https://opentrons.atlassian.net/browse/PLAT-309)

We make a lot of builds, which is great for having a pulse on the system. However, this leads to excessive builds that are never used, costing us computation time and money. This pull request fixes this problem (or greatly mitigates it) by adding Github [concurrency](https://docs.github.com/en/actions/using-jobs/using-concurrency) to the workflow, which cancels queued builds with the same signature. The build signature is just a concatenated string of the monorepo, buildroot refs, plus build variant and build-type used when building the image. Here are some examples,
```
'refs/heads/edge refs/heads/opentrons-develop internal-release release'
'refs/tags/v7.3.0-alpha.2 refs/tags/v0.6.4 refs/tags/v50 release release'
```
This means that a build will start right away if there are no other builds in progress; when another build with the same signature is added, it will be queued as they do now. However, if we now have a build in-progress, a build queued, and a new build with the same signature is added to the queue, the currently queued build will be canceled, as seen in the image below. So at any given time, we can have one in-progress build and, at most, one queued build of the same signature.
![Screen Shot 2024-05-15 at 10 29 43 AM](https://github.com/Opentrons/buildroot/assets/12740774/6d4bd421-4d5a-422a-bf91-8e74a2d01175)


[PLAT-309]: https://opentrons.atlassian.net/browse/PLAT-309?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ