### PR TITLE
fix(ci): upload-artifact v3 to v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,10 +35,9 @@ jobs:
       monorepo: ${{ steps.build-refs.outputs.monorepo }}
       variant: ${{ steps.build-refs.outputs.variant }}
       build-type: ${{ steps.build-refs.outputs.build-type }}
-
     steps:
       - name: Check out sources for action
-        uses: 'actions/checkout@v3'
+        uses: 'actions/checkout@v4'
         with:
           path: ./buildroot-for-workflow
       - name: Get the refs
@@ -48,6 +47,17 @@ jobs:
           token: ${{ github.token }}
           monorepo: ${{ inputs.monorepo-ref }}
           buildroot: ${{ inputs.buildroot-ref }}
+      - name: Add refs to job summary
+        run: |
+          echo "### Decide refs" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Parameter | Value |" >> $GITHUB_STEP_SUMMARY
+          echo "|-----------|-------|" >> $GITHUB_STEP_SUMMARY
+          echo "| **buildroot** | ${{ steps.build-refs.outputs.buildroot }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| **monorepo** | ${{ steps.build-refs.outputs.monorepo }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| **variant** | ${{ steps.build-refs.outputs.variant }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| **build type** | ${{ steps.build-refs.outputs.build-type }} |" >> $GITHUB_STEP_SUMMARY
+
   run-build:
     needs: decide-refs
     strategy:
@@ -163,7 +173,7 @@ jobs:
           docker run ${{steps.docker-args.outputs.args}} all
       - name: Upload build log result
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: buildlog.txt
           path: ./buildroot/buildlog.txt

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
           token: ${{ github.token }}
           monorepo: ${{ inputs.monorepo-ref }}
           buildroot: ${{ inputs.buildroot-ref }}
-      - name: Add refs to job summary
+      - name: Add refs to the summary
         run: |
           echo "### Decide refs" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Found during build of 8.3.0-alpha.4

Job <https://github.com/Opentrons/buildroot/actions/runs/13065018762>
failed due to 
<https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/>

- [x] upgraded <https://github.com/actions/upload-artifact> to v4
- [x] upgraded <https://github.com/actions/checkout> to v4
- [x] added a summary so I may verify the build refs quickly during the release process