### PR TITLE
board/opentrons/ot2: Increase nginx header limit to 64k for long URLs

### DIFF
--- a/board/opentrons/ot2/rootfs-overlay/etc/nginx/nginx.conf
+++ b/board/opentrons/ot2/rootfs-overlay/etc/nginx/nginx.conf
@@ -16,9 +16,10 @@ http {
         listen [::]:31950;
         listen 0.0.0.0:31950;
 
-        client_body_in_file_only off;
-        client_body_buffer_size  128k;
-        client_max_body_size     2M;
+        client_body_in_file_only    off;
+        client_body_buffer_size     128k;
+        client_max_body_size        2M;
+        large_client_header_buffers 4 64k;
 
         access_log /data/nginx-access.log;
 


### PR DESCRIPTION
See [EXEC-1294](https://opentrons.atlassian.net/browse/EXEC-1294).

Same thing in oe-core: https://github.com/Opentrons/oe-core/pull/193

[EXEC-1294]: https://opentrons.atlassian.net/browse/EXEC-1294?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ