### PR TITLE
chore: Fix GitHub Actions wildcards

### DIFF
--- a/.github/workflows/build-branches.yml
+++ b/.github/workflows/build-branches.yml
@@ -3,9 +3,9 @@ run-name: 'Starting a branch build of OT2 software for ${{github.ref_name}}'
 on:
   push:
     branches:
-      - '*'
+      - '**'
     tags-ignore:
-      - '*'
+      - '**'
 
 jobs:
   start-build:

--- a/.github/workflows/update-container.yaml
+++ b/.github/workflows/update-container.yaml
@@ -1,9 +1,9 @@
 on:
   push:
     tags:
-      - "*"
+      - "**"
     branches_ignore:
-      - "*"
+      - "**"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Same thing as https://github.com/Opentrons/opentrons/pull/18172.

Some existing wildcards in our GitHub actions are not matching the `/` character, and I think that's causing CI to not run on Dependabot PRs like https://github.com/Opentrons/buildroot/pull/244 because they have `/` in the branch name.