### PR TITLE
package/opentrons-temperature-module-firmware: use correct version link to v2.1.1 tempdeck binary.

### DIFF
--- a/package/opentrons/opentrons-temperature-module-firmware/opentrons-temperature-module-firmware.hash
+++ b/package/opentrons/opentrons-temperature-module-firmware/opentrons-temperature-module-firmware.hash
@@ -1,2 +1,2 @@
 # locally computed
-sha256 44df799b54d5488a81727e36dad0cdc523ab8694f5d710d0a334abd774886d65 temp-deck-arduino.ino.hex
+sha256 b8f1d74007a73c85aa64c4e7b2d269c8a61f78cfc41f04526f30dc13f25cbc4a temp-deck-arduino.ino.hex

--- a/package/opentrons/opentrons-temperature-module-firmware/opentrons-temperature-module-firmware.mk
+++ b/package/opentrons/opentrons-temperature-module-firmware/opentrons-temperature-module-firmware.mk
@@ -6,7 +6,7 @@
 
 OPENTRONS_TEMPERATURE_MODULE_FIRMWARE_VERSION=v2.1.1
 OPENTRONS_TEMPERATURE_MODULE_FIRMWARE_SOURCE=temp-deck-arduino.ino.hex
-OPENTRONS_TEMPERATURE_MODULE_FIRMWARE_SITE=https://opentrons-modules-builds.s3.us-east-2.amazonaws.com/modules-magdeck@v2.0.1-/tempdeck
+OPENTRONS_TEMPERATURE_MODULE_FIRMWARE_SITE=https://opentrons-modules-builds.s3.us-east-2.amazonaws.com/modules-magdeck@v2.1.1-/tempdeck
 OPENTRONS_TEMPERATURE_MODULE_FIRMWARE_LICENSE=Apache-2.0
 
 # not downloaded in a tarball so don't extract


### PR DESCRIPTION
The wrong link was used to download the tempdeck v2.1.1 firmware; we were downloading v2.0.1 and renaming it to v2.1.1 instead.

Fixes: [RQA-4587](https://opentrons.atlassian.net/browse/RQA-4587)

[RQA-4587]: https://opentrons.atlassian.net/browse/RQA-4587?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ