### PR TITLE
Revert "package/opentrons-temperature-module-firmware: use correct ve…

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -163,6 +163,33 @@ jobs:
         run: |
           cd buildroot
           docker run ${{steps.docker-args.outputs.args}} ot2_defconfig
+
+      - name: Hackily delete incorrectly-cached module firmwares
+        # the arduino module firmwares do not have their versions as part of their filenames, which means
+        # that buildroot will not detect previously-downloaded (and previously-versioned) module firmware packages
+        # as stale and update them. Since they are also tiny, just neatly brush them away before doing a build to
+        # force a redownload.
+        # because buildroot is Like That, brushing them away requires manually poking in the output build directory
+        # and removing the cache there too; removing the downloaded artifact isn't enough. There also isn't a
+        # per-recipe clean step.
+        run: |
+          echo "Downloads before delete"
+          ls ${{steps.cache-setup.outputs.downloads}}
+          rm -rf ${{steps.cache-setup.outputs.downloads}}/opentrons-temperature-module-firmware
+          rm -rf ${{steps.cache-setup.outputs.downloads}}/opentrons-magnetic-module-firmware
+          echo "Downloads after delete"
+          ls ${{steps.cache-setup.outputs.downloads}}
+          if [ -d ${{steps.cache-setup.outputs.output}}/build ] ; then
+            echo "Build before delete"
+            ls ${{steps.cache-setup.outputs.output}}/build
+            rm -rf ${{steps.cache-setup.outputs.output}}/build/opentrons-temperature-module-firmware-*
+            rm -rf ${{steps.cache-setup.outputs.output}}/build/opentrons-magnetic-module-firmware-*
+            echo "Build after delete"
+            ls ${{steps.cache-setup.outputs.output}}/build
+          else
+            echo "No output/builds in"
+            ls ${{steps.cache-setup.outputs.output}}
+          fi
       - name: Download package sources
         run: |
           cd buildroot

--- a/package/opentrons/opentrons-temperature-module-firmware/opentrons-temperature-module-firmware.hash
+++ b/package/opentrons/opentrons-temperature-module-firmware/opentrons-temperature-module-firmware.hash
@@ -1,2 +1,2 @@
 # locally computed
-sha256 b8f1d74007a73c85aa64c4e7b2d269c8a61f78cfc41f04526f30dc13f25cbc4a temp-deck-arduino.ino.hex
+sha256 44df799b54d5488a81727e36dad0cdc523ab8694f5d710d0a334abd774886d65 temp-deck-arduino.ino.hex

--- a/package/opentrons/opentrons-temperature-module-firmware/opentrons-temperature-module-firmware.mk
+++ b/package/opentrons/opentrons-temperature-module-firmware/opentrons-temperature-module-firmware.mk
@@ -6,7 +6,7 @@
 
 OPENTRONS_TEMPERATURE_MODULE_FIRMWARE_VERSION=v2.1.1
 OPENTRONS_TEMPERATURE_MODULE_FIRMWARE_SOURCE=temp-deck-arduino.ino.hex
-OPENTRONS_TEMPERATURE_MODULE_FIRMWARE_SITE=https://opentrons-modules-builds.s3.us-east-2.amazonaws.com/modules-magdeck@v2.1.1-/tempdeck
+OPENTRONS_TEMPERATURE_MODULE_FIRMWARE_SITE=https://opentrons-modules-builds.s3.us-east-2.amazonaws.com/modules-magdeck@v2.0.1-/tempdeck
 OPENTRONS_TEMPERATURE_MODULE_FIRMWARE_LICENSE=Apache-2.0
 
 # not downloaded in a tarball so don't extract


### PR DESCRIPTION
…rsion link to v2.1.1 tempdeck binary. (#252)"

This reverts commit c5b8713dda53c8816b9378edb3208450b905b2b8.

The correct url is definitely the magdeck@v2.0.1 one; magdeck@v2.1.1 does not exist. It shouldn't be magdeck at all, but is because the modules build pulled the wrong tag. This change was originally made I think because buildroot isn't properly invalidating the download for some reason and reusing the old module firmware file.