### PR TITLE
package/python-pip: keep called files in pyc-only

### DIFF
--- a/package/python-pip/python-pip.mk
+++ b/package/python-pip/python-pip.mk
@@ -12,6 +12,8 @@ PYTHON_PIP_LICENSE = MIT
 PYTHON_PIP_LICENSE_FILES = LICENSE.txt
 PYTHON_PIP_CPE_ID_VENDOR = pypa
 PYTHON_PIP_CPE_ID_PRODUCT = pip
+PYTHON_PIP_KEEP_PY_FILES += usr/lib/python$(PYTHON3_VERSION_MAJOR)/site-packages/pip/__pip-runner__.py \
+                            usr/lib/python$(PYTHON3_VERSION_MAJOR)/site-packages/pip/_vendor/pep517/in_process/_in_process.py
 # Disputed CVE: things work as designed, and only affects the
 # --extra-index-url option. This CVE will never be fixed.
 PYTHON_PIP_IGNORE_CVES += CVE-2018-20225


### PR DESCRIPTION
If you set BR2_PACKAGE_PYTHON3_PYC_ONLY, then buildroot adds a hook to remove all .py files in favor of their compiled counterparts. Pip has some machinery that invokes some of its own .py files on the command line by name, and this machinery breaks if only the .pyc equivalent of those files is present.

Specifically, __pip-runner__.py is used to install build dependencies during a pep517 build (isolated or non-isolated) and _in_process.py is used to install dependencies during a non-isolated build; both should be kept with the $(PACKAGE)_KEEP_PY_FILES mechanism.