### PR TITLE
fix(ci,build): Debian eol fix

### DIFF
--- a/.github/workflows/build-branches.yml
+++ b/.github/workflows/build-branches.yml
@@ -17,14 +17,14 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
-          route: POST /repos/{owner}/{repo}/actions/workflows/{workflow-id}/dispatches
-          owner: opentrons
-          repo: buildroot
-          workflow-id: build.yml
-          ref: ${{github.ref}}
-          inputs: |
+          route: POST /repos/opentrons/buildroot/actions/workflows/build.yml/dispatches
+          mediaType: '{"previews": ["wyandotte"]}'
+          data: |
             {
-              "buildroot-ref": "${{ github.ref }}",
-              "monorepo-ref": "-",
-              "infra-stage": "stage-prod"
+              "ref": "${{ github.ref }}",
+              "inputs": {
+                "buildroot-ref": "${{ github.ref }}",
+                "monorepo-ref": "-",
+                "infra-stage": "stage-prod"
+              }
             }

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,11 @@ ARG filter_output
 
 VOLUME /buildroot
 
+# Configure archive repositories for Debian Buster (EOL)
+RUN echo "deb http://archive.debian.org/debian buster main" > /etc/apt/sources.list &&\
+  echo "deb http://archive.debian.org/debian-security buster/updates main" >> /etc/apt/sources.list &&\
+  echo "Acquire::Check-Valid-Until false;" > /etc/apt/apt.conf.d/99no-check-valid-until
+
 RUN apt-get -y update &&\
   apt-get -y install build-essential wget file cpio python rsync unzip bc libncurses-dev git curl
 


### PR DESCRIPTION
### Fix Docker build and GitHub Actions workflow warnings

Changes:
1. Fix Debian Buster EOL Docker build failure
Problem: Docker build failing with 404 errors because Debian 10 (Buster) went EOL on June 30, 2024
Solution: Configure Dockerfile to use archive repositories (archive.debian.org) instead of standard repositories
Files: Dockerfile
2. Fix octokit/request-action deprecation warning
Problem: Warning about unexpected inputs (owner, repo, workflow-id, ref, inputs) in octokit/request-action@v2.x
Solution: Updated workflow to use the correct API format with route values and data parameter
Files: .github/workflows/build-branches.yml

Technical Details
This issue became apparent only after the tagging fix was pushed out.
Added archive repository configuration for Debian Buster in Dockerfile
Updated build-branches.yml to use the new octokit/request-action API format
Maintained compatibility with existing workflow functionality

Result
Docker builds now complete successfully
GitHub Actions workflow runs without deprecation warnings
All functionality preserved