### PR TITLE
refactor: broaden camera udev rule

### DIFF
--- a/board/opentrons/ot2/rootfs-overlay/etc/udev/rules.d/95-opentrons-udev.rules
+++ b/board/opentrons/ot2/rootfs-overlay/etc/udev/rules.d/95-opentrons-udev.rules
@@ -8,4 +8,4 @@ KERNEL=="ttyACM[0-9]*", SUBSYSTEMS=="usb", ATTRS{idProduct}=="800b", ATTRS{idVen
 KERNEL=="ttyACM[0-9]*", SUBSYSTEMS=="usb", ATTRS{idProduct}=="4853", ATTRS{idVendor}=="0483", SYMLINK+="ot_module_heatershaker%n"
 # gen2 thermocycler on stm32:
 KERNEL=="ttyACM[0-9]*", SUBSYSTEMS=="usb", ATTRS{idProduct}=="ed8d", ATTRS{idVendor}=="0483", SYMLINK+="ot_module_thermocycler%n"
-KERNEL=="video[0-9]*", DEVPATH=="*/3f980000.usb/usb1/1-1/1-1.4/*", ATTR{index}=="0", SYMLINK+="ot_system_camera"
+KERNEL=="video[0-9]*", SUBSYSTEMS=="usb", ATTRS{bInterfaceClass}=="0e", ATTRS{idVendor}=="0424", ATTR{index}=="0", SYMLINK+="ot_system_camera"

--- a/board/opentrons/ot2/rootfs-overlay/etc/udev/rules.d/95-opentrons-udev.rules
+++ b/board/opentrons/ot2/rootfs-overlay/etc/udev/rules.d/95-opentrons-udev.rules
@@ -8,4 +8,4 @@ KERNEL=="ttyACM[0-9]*", SUBSYSTEMS=="usb", ATTRS{idProduct}=="800b", ATTRS{idVen
 KERNEL=="ttyACM[0-9]*", SUBSYSTEMS=="usb", ATTRS{idProduct}=="4853", ATTRS{idVendor}=="0483", SYMLINK+="ot_module_heatershaker%n"
 # gen2 thermocycler on stm32:
 KERNEL=="ttyACM[0-9]*", SUBSYSTEMS=="usb", ATTRS{idProduct}=="ed8d", ATTRS{idVendor}=="0483", SYMLINK+="ot_module_thermocycler%n"
-KERNEL=="video[0-9]*", SUBSYSTEMS=="usb", ATTRS{bInterfaceClass}=="0e", ATTRS{idVendor}=="0424", ATTR{index}=="0", SYMLINK+="ot_system_camera"
+KERNEL=="video[0-9]*", SUBSYSTEMS=="usb", ATTRS{idProduct}=="9422", ATTRS{idVendor}=="32e4", ATTR{index}=="0", SYMLINK+="ot_system_camera"


### PR DESCRIPTION
# Overview

We can't guarantee OT-2s are manufactured the camera plugged into the same USB port consistently, so let's broaden the udev rule.

This updated rule matches based on video class device, `bInterfaceClass` and vendor id (the hub vendor).

# Review requests

Should we also match the hub by product id for increased specificity? Would such a  rule unnecessarily constraining or misguided given manufacturing practices?

# Testing

Will test a build before merging.