### PR TITLE
fix(ci): more unquoted vars

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -150,7 +150,7 @@ jobs:
         id: get-image
         run: |
           cd buildroot
-          if [ ${{inputs.build-own-container}} = "true" ] ; then
+          if [ "${{inputs.build-own-container}}" = "true" ] ; then
             imgname=$(./opentrons-build-container.sh pull || ./opentrons-build-container.sh build)
           else
             imgname=$(./opentrons-build-container.sh build)
@@ -165,7 +165,7 @@ jobs:
       - name: Set up docker args
         id: docker-args
         run: |
-          if [ ${{needs.decide-refs.outputs.variant}} = "release" ] ; then
+          if [ "${{needs.decide-refs.outputs.variant}}" = "release" ] ; then
              _project=robot-stack
           else
             _project=ot3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -150,7 +150,7 @@ jobs:
         id: get-image
         run: |
           cd buildroot
-          if [ "${{inputs.build-own-container}}" = "true" ] ; then
+          if [ "${{inputs.force-own-container}}" = "true" ] ; then
             imgname=$(./opentrons-build-container.sh pull || ./opentrons-build-container.sh build)
           else
             imgname=$(./opentrons-build-container.sh build)


### PR DESCRIPTION
Fixed two unquoted variables in the workflow file.

The commit that added this feature shows the bug was introduced from the start:
- The input was defined as force-own-container (line 27)
- But the code referenced inputs.build-own-container (line 153)
This mismatch was present when the feature was added. It likely didn’t surface because:
- The input wasn’t used, so that code path didn’t run
- Or it was used, but the unquoted variable didn’t error if the value was non-empty (though it would always be empty due to the wrong name)