### PR TITLE
board/opentrons/ot2: fix signing key path

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,7 @@ on:
           True to sign the build even if it's not a release.
         required: false
         default: false
+        type: boolean
 
 env:
   CI: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,11 @@ on:
         required: false
         default: false
         type: boolean
+      force-sign:
+        description: |
+          True to sign the build even if it's not a release.
+        required: false
+        default: false
 
 env:
   CI: true
@@ -158,7 +163,7 @@ jobs:
           echo "image-name=$imgname" >> $GITHUB_OUTPUT
 
       - name: Set up signing
-        if: needs.decide-refs.outputs.build-type == 'release'
+        if: needs.decide-refs.outputs.build-type == 'release' || inputs.force-sign == true
         run: |
           echo "${{secrets.ROBOT_SIGNING_KEY}}" > ./buildroot/.signing-key
 

--- a/board/opentrons/ot2/post-image.sh
+++ b/board/opentrons/ot2/post-image.sh
@@ -74,7 +74,7 @@ else
     echo "Build type is NOT RELEASE"
 fi
 
-if [ -e .signing-key ]; then
+if [ -e ${BR2_EXTERNAL_OPENTRONS_BUILDROOT_OVERLAYS_PATH}/.signing-key ]; then
     echo "Signing rootfs hash"
     openssl dgst -sha256 -sign ${BR2_EXTERNAL_OPENTRONS_BUILDROOT_OVERLAYS_PATH}/.signing-key -out ${BINARIES_DIR}/rootfs.ext4.hash.sig ${BINARIES_DIR}/rootfs.ext4.hash
     system_files="${BINARIES_DIR}/rootfs.ext4 ${BINARIES_DIR}/rootfs.ext4.hash ${BINARIES_DIR}/VERSION.json ${BINARIES_DIR}/rootfs.ext4.hash.sig ${boot_files}"


### PR DESCRIPTION
The signing key path was correctly updated when using it... but not when checking its existence.

Closes RQA-5088