### PR TITLE
ot2: fix network ifaces and jupyter and smoothie firmware

### DIFF
--- a/board/opentrons/ot2/rootfs-overlay/etc/systemd/system/install-deferred-packages.service
+++ b/board/opentrons/ot2/rootfs-overlay/etc/systemd/system/install-deferred-packages.service
@@ -3,13 +3,14 @@
 [Unit]
 Description=Install deferred python packages
 Before=jupyter-notebook.service
-Before=basic.target
-Before=opentrons-robot-server.service
-Before=opentrons-update-server.service
+Wants=local-fs.target
+After=local-fs.target
 
 [Service]
 Type=oneshot
 ExecStart=/usr/bin/mkdir -p /var/system-packages/usr/lib/python3.12/site-packages
+RemainAfterExit=yes
+TimeoutStartSec=5m
 
 [Install]
-WantedBy=basic.target
+WantedBy=basic.target juypter-notebook.service

--- a/board/opentrons/ot2/rootfs-overlay/etc/systemd/system/install-deferred-packages.service
+++ b/board/opentrons/ot2/rootfs-overlay/etc/systemd/system/install-deferred-packages.service
@@ -12,5 +12,4 @@ Type=oneshot
 ExecStart=/usr/bin/mkdir -p /var/system-packages/usr/lib/python3.12/site-packages
 
 [Install]
-WantedBy=jupyter-notebook.service
 WantedBy=basic.target

--- a/board/opentrons/ot2/rootfs-overlay/etc/systemd/system/jupyter-notebook.service.wants/install-deferred-packages.service
+++ b/board/opentrons/ot2/rootfs-overlay/etc/systemd/system/jupyter-notebook.service.wants/install-deferred-packages.service
@@ -1,0 +1,1 @@
+../install-deferred-packages.service

--- a/board/opentrons/ot2/rootfs-overlay/etc/systemd/system/opentrons-status-leds.service
+++ b/board/opentrons/ot2/rootfs-overlay/etc/systemd/system/opentrons-status-leds.service
@@ -1,6 +1,8 @@
 [Unit]
 Description=Opentrons: Run status LEDs
 Before=opentrons-robot-server.service
+Wants=NetworkManager.service
+After=NetworkManager.service
 
 [Service]
 Type=notify

--- a/board/opentrons/ot2/rootfs-overlay/etc/udev/rules.d/10-eth0.rules
+++ b/board/opentrons/ot2/rootfs-overlay/etc/udev/rules.d/10-eth0.rules
@@ -1,0 +1,2 @@
+# bind the usb ethernet adapter to eth0 for compatibility with pre-9.0.0
+ACTION=="add", SUBSYSTEM=="net", SUBSYSTEMS=="usb", ATTRS{idVendor}=="0424", ATTRS{idProduct}=="ec00", NAME="eth0"

--- a/package/opentrons/opentrons-magnetic-module-firmware/opentrons-magnetic-module-firmware.hash
+++ b/package/opentrons/opentrons-magnetic-module-firmware/opentrons-magnetic-module-firmware.hash
@@ -1,2 +1,2 @@
 # locally computed
-sha256 ff282bd82c9a3cfa4ad1d45dc7e8fff749cb2957b1b0ec0e5cabc04eb4d14d6c mag-deck-arduino.ino.hex
+sha256 73521fad30423617eb7294eb4f2b479a3710b58ef144b5dae32baacc364a91c9 mag-deck-arduino.ino.hex

--- a/package/opentrons/opentrons-temperature-module-firmware/opentrons-temperature-module-firmware.hash
+++ b/package/opentrons/opentrons-temperature-module-firmware/opentrons-temperature-module-firmware.hash
@@ -1,2 +1,2 @@
 # locally computed
-sha256 44df799b54d5488a81727e36dad0cdc523ab8694f5d710d0a334abd774886d65 temp-deck-arduino.ino.hex
+sha256 b8f1d74007a73c85aa64c4e7b2d269c8a61f78cfc41f04526f30dc13f25cbc4a temp-deck-arduino.ino.hex

--- a/package/opentrons/opentrons.mk
+++ b/package/opentrons/opentrons.mk
@@ -1,1 +1,1 @@
-include $(sort $(wildcard package/opentrons/*/*.mk))
+include $(sort $(wildcard $(BR2_EXTERNAL_OPENTRONS_BUILDROOT_OVERLAYS_PATH)/package/opentrons/*/*.mk))


### PR DESCRIPTION
Fix three issues: 
- The ethernet interface got renamed, which broke connections to local networks (and also the blinkielights script, which broke some gpio stuff), so change it back
- The systemd unit that puts jupyter's dependencies in the right place had the wrong kind of symlink for systemd
- We weren't actually including the subtree that puts modules and smoothie firmware on the filesystem, so the module firmwares aren't there to update and machines that need (relatively) more recent smoothie firmware don't work.

Now jupyter boots and local networks work, and recent machines can home again.

Closes RQA-5170
Closes RQA-5171
Closes RQA-5172