### PR TITLE
fix(ci): tolerate missing S3 releases.json on first OT-2 release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -689,7 +689,8 @@ jobs:
         shell: bash
         run: |
           pushd buildroot
-          aws s3 cp --acl=public-read s3://${{steps.upload-results.outputs.machine_root}}/releases.json releases.json
+          # First release: object may not exist yet; update_releases_file.py seeds an empty manifest.
+          aws s3 cp --acl=public-read s3://${{steps.upload-results.outputs.machine_root}}/releases.json releases.json || true
           python3 update_releases_file.py --releases-file releases.json --version-file ${{steps.artifact-copy.outputs.version_json}} --base-url ${{ steps.upload-results.outputs.root_url }}
           aws s3 cp --acl=public-read releases.json s3://${{steps.upload-results.outputs.machine_root}}/releases.json
           popd


### PR DESCRIPTION
aws s3 cp fails with HeadObject 404 when ot2-br/releases.json does not exist yet. Allow the download to fail; update_releases_file.py already starts from an empty production map when the local file is absent.