### PR TITLE
fix(ci): Internal tag fix

### DIFF
--- a/.github/actions/build-refs/action/__tests__/index.test.ts
+++ b/.github/actions/build-refs/action/__tests__/index.test.ts
@@ -145,12 +145,6 @@ const BUILD_TYPE_TEST_SPECS: Array<[string, [Ref], BuildType, Variant]> = [
     'internal-release',
   ],
   [
-    'when monorepo ref is a ot3-prefix tag is release on i-r',
-    ['refs/tags/ot3@0.0.0-dev'],
-    'release',
-    'internal-release',
-  ],
-  [
     'when monorepo ref is a internal-prefix tag is release on i-r',
     ['refs/tags/internal@0.0.0-dev'],
     'release',
@@ -178,12 +172,6 @@ const BUILD_TYPE_TEST_SPECS: Array<[string, [Ref], BuildType, Variant]> = [
     'when monorepo ref is a v-prefix tag is release on f-r',
     ['refs/tags/v0.0.0-dev'],
     'release',
-    'release',
-  ],
-  [
-    'when monorepo ref is ot3-tag is develop on f-r',
-    ['refs/tags/ot3@0.0.0-dev'],
-    'develop',
     'release',
   ],
   [
@@ -235,7 +223,7 @@ const VARIANT_TEST_SPECS: Array<[string, Ref, Variant]> = [
   ['when monorepo ref is a release tag', 'refs/tags/v123.213.8', 'release'],
   [
     'when monorepo ref is an internal-release tag',
-    'refs/tags/ot3@0.1231.8-alpha.2',
+    'refs/tags/internal@0.1231.8-alpha.2',
     'internal-release',
   ],
 ]

--- a/.github/actions/build-refs/action/__tests__/index.test.ts
+++ b/.github/actions/build-refs/action/__tests__/index.test.ts
@@ -151,6 +151,12 @@ const BUILD_TYPE_TEST_SPECS: Array<[string, [Ref], BuildType, Variant]> = [
     'internal-release',
   ],
   [
+    'when monorepo ref is a internal-prefix tag is release on i-r',
+    ['refs/tags/internal@0.0.0-dev'],
+    'release',
+    'internal-release',
+  ],
+  [
     'when monorepo ref is a v-tag is develop on i-r',
     ['refs/tags/v0.0.0-dev'],
     'develop',
@@ -177,6 +183,12 @@ const BUILD_TYPE_TEST_SPECS: Array<[string, [Ref], BuildType, Variant]> = [
   [
     'when monorepo ref is ot3-tag is develop on f-r',
     ['refs/tags/ot3@0.0.0-dev'],
+    'develop',
+    'release',
+  ],
+  [
+    'when monorepo ref is internal-tag is develop on f-r',
+    ['refs/tags/internal@0.0.0-dev'],
     'develop',
     'release',
   ],

--- a/.github/actions/build-refs/action/index.ts
+++ b/.github/actions/build-refs/action/index.ts
@@ -295,8 +295,7 @@ async function resolveRefs(
 }
 
 function resolveBuildTypeInternal(ref: Ref): BuildType {
-  return ref.includes('refs/tags/ot3@') ||
-    ref.includes('refs/tags/internal@')
+  return ref.includes('refs/tags/internal@')
     ? 'release'
     : 'develop'
 }

--- a/.github/actions/build-refs/action/index.ts
+++ b/.github/actions/build-refs/action/index.ts
@@ -63,9 +63,7 @@ export function variantForRef(ref: Ref): Variant {
       return 'release'
     }
   } else if (ref.startsWith('refs/tags')) {
-    if (ref.includes('ot3@')) {
-      return 'internal-release'
-    } else if (ref.startsWith('refs/tags/v')) {
+    if (ref.startsWith('refs/tags/v')) {
       return 'release'
     }
   }
@@ -92,9 +90,6 @@ function latestTagPrefixFor(repo: Repo, variant: Variant): string[] {
     return ['refs/tags/v']
   }
   if (variant === 'internal-release') {
-    if (repo === 'monorepo') {
-      return ['refs/tags/internal@', 'refs/tags/ot3@']
-    }
     return ['refs/tags/internal@']
   }
   throw new Error(`Unknown variant ${variant}`)
@@ -117,12 +112,6 @@ export function latestTag(tagRefs: GitHubApiTag[]): Tag | null {
       // Handle internal@* tags (e.g., "internal@1.2.0-alpha.0")
       if (tagName.startsWith('internal@')) {
         const version = tagName.substring(9) // Remove "internal@"
-        return { tag: tag.ref, version, isValid: semver.valid(version) }
-      }
-
-      // Handle ot3@* tags (e.g., "ot3@1.2.0-alpha.0")
-      if (tagName.startsWith('ot3@')) {
-        const version = tagName.substring(4) // Remove "ot3@"
         return { tag: tag.ref, version, isValid: semver.valid(version) }
       }
 

--- a/.github/actions/build-refs/action/index.ts
+++ b/.github/actions/build-refs/action/index.ts
@@ -295,7 +295,10 @@ async function resolveRefs(
 }
 
 function resolveBuildTypeInternal(ref: Ref): BuildType {
-  return ref.includes('refs/tags/ot3@') ? 'release' : 'develop'
+  return ref.includes('refs/tags/ot3@') ||
+    ref.includes('refs/tags/internal@')
+    ? 'release'
+    : 'develop'
 }
 
 function resolveBuildTypeExternal(ref: Ref): BuildType {

--- a/.github/actions/build-refs/dist/index.js
+++ b/.github/actions/build-refs/dist/index.js
@@ -32176,10 +32176,7 @@ function variantForRef(ref) {
         }
     }
     else if (ref.startsWith('refs/tags')) {
-        if (ref.includes('ot3@')) {
-            return 'internal-release';
-        }
-        else if (ref.startsWith('refs/tags/v')) {
+        if (ref.startsWith('refs/tags/v')) {
             return 'release';
         }
     }
@@ -32199,9 +32196,6 @@ function latestTagPrefixFor(repo, variant) {
         return ['refs/tags/v'];
     }
     if (variant === 'internal-release') {
-        if (repo === 'monorepo') {
-            return ['refs/tags/internal@', 'refs/tags/ot3@'];
-        }
         return ['refs/tags/internal@'];
     }
     throw new Error(`Unknown variant ${variant}`);
@@ -32221,11 +32215,6 @@ function latestTag(tagRefs) {
         // Handle internal@* tags (e.g., "internal@1.2.0-alpha.0")
         if (tagName.startsWith('internal@')) {
             const version = tagName.substring(9); // Remove "internal@"
-            return { tag: tag.ref, version, isValid: semver__WEBPACK_IMPORTED_MODULE_3__.valid(version) };
-        }
-        // Handle ot3@* tags (e.g., "ot3@1.2.0-alpha.0")
-        if (tagName.startsWith('ot3@')) {
-            const version = tagName.substring(4); // Remove "ot3@"
             return { tag: tag.ref, version, isValid: semver__WEBPACK_IMPORTED_MODULE_3__.valid(version) };
         }
         // Unknown tag format
@@ -32328,8 +32317,7 @@ function resolveRefs(toAttempt, variant, fork) {
     });
 }
 function resolveBuildTypeInternal(ref) {
-    return ref.includes('refs/tags/ot3@') ||
-        ref.includes('refs/tags/internal@')
+    return ref.includes('refs/tags/internal@')
         ? 'release'
         : 'develop';
 }

--- a/.github/actions/build-refs/dist/index.js
+++ b/.github/actions/build-refs/dist/index.js
@@ -32328,7 +32328,10 @@ function resolveRefs(toAttempt, variant, fork) {
     });
 }
 function resolveBuildTypeInternal(ref) {
-    return ref.includes('refs/tags/ot3@') ? 'release' : 'develop';
+    return ref.includes('refs/tags/ot3@') ||
+        ref.includes('refs/tags/internal@')
+        ? 'release'
+        : 'develop';
 }
 function resolveBuildTypeExternal(ref) {
     return ref.includes('refs/tags/v') ? 'release' : 'develop';

--- a/.github/actions/simple-build-alert/README.md
+++ b/.github/actions/simple-build-alert/README.md
@@ -34,10 +34,10 @@ A lightweight GitHub Action that sends Slack notifications for tagged build fail
 
 The action automatically routes notifications to different Slack channels based on the tag pattern:
 
-### Main Releases → `#release-cycle`
+### Main & internal releases → `#release-cycle`
 
-- `v*` - Version releases (v7.2.0, v8.0.0, etc.)
-- `ot3@*` - OT3 releases (ot3@7.2.0, ot3@8.0.0, etc.)
+- `v*` — public semver tags (e.g. `v7.2.0`, `v8.0.0`)
+- `internal@*` — internal semver tags (e.g. `internal@1.2.0-alpha.0`), same channel routing as `v*`
 
 ### Component Releases → `#builds`
 
@@ -71,7 +71,7 @@ You need to set up these repository secrets:
 
 - **Secret Name**: `OT_APP_RELEASE_SLACK_NOTIFICATION_WEBHOOK_URL`
 - **Channel**: `#release-cycle`
-- **Used for**: Main releases (v*, ot3@*)
+- **Used for**: Main and internal releases (`v*`, `internal@*`)
 
 ### 2. Builds Channel Webhook
 
@@ -205,8 +205,10 @@ View Details: [Open Workflow]
 ### Test with Real Tags
 
 ```bash
-# Test main release (goes to #release-cycle)
+# Test main or internal release (goes to #release-cycle)
 git tag v7.2.0-test && git push origin v7.2.0-test
+# or
+git tag internal@1.0.0-test && git push origin internal@1.0.0-test
 
 # Test component release (goes to #builds)
 git tag protocol-designer-v1.0.0-test && git push origin protocol-designer-v1.0.0-test


### PR DESCRIPTION
build-refs: resolveBuildTypeInternal now treats refs/tags/internal@… like refs/tags/ot3@…, so build-type is release for internal-release tag flows. 