### PR TITLE
update internal release tag to `internal@`

### DIFF
--- a/.github/actions/build-refs/action/__tests__/index.test.ts
+++ b/.github/actions/build-refs/action/__tests__/index.test.ts
@@ -145,8 +145,8 @@ const BUILD_TYPE_TEST_SPECS: Array<[string, [Ref], BuildType, Variant]> = [
     'internal-release',
   ],
   [
-    'when monorepo ref is a ot3-prefix tag is release on i-r',
-    ['refs/tags/ot3@0.0.0-dev'],
+    'when monorepo ref is an internal-prefix tag is release on i-r',
+    ['refs/tags/internal@3.0.0-alpha.3'],
     'release',
     'internal-release',
   ],

--- a/.github/actions/build-refs/action/index.ts
+++ b/.github/actions/build-refs/action/index.ts
@@ -295,7 +295,7 @@ async function resolveRefs(
 }
 
 function resolveBuildTypeInternal(ref: Ref): BuildType {
-  return ref.includes('refs/tags/ot3@') ? 'release' : 'develop'
+  return ref.includes('refs/tags/internal@') ? 'release' : 'develop'
 }
 
 function resolveBuildTypeExternal(ref: Ref): BuildType {


### PR DESCRIPTION
# Overview

We've been tagging IR builds with an `internal@` prefix after separating the OT-2 from the modern monorepo, but I think we need to adjust the tagging structure so we properly add internal releases to the manifest? 

# Review requests

Is this assumption correct?