### PR TITLE
feat(ci): use repository variables for ephemeral runner API URLs

### DIFF
--- a/.github/workflows/RUNNER_SECRETS.md
+++ b/.github/workflows/RUNNER_SECRETS.md
@@ -1,8 +1,10 @@
-# Ephemeral runner API secrets (buildroot)
+# Ephemeral runner API variables (buildroot)
 
 Workflow: `build.yml` job `initialize-infra` runs `initialize_runner.py`, which picks static vs ephemeral runners from **variant** (`internal-release` vs `release`), fork status, and `force-ephemeral-infra`.
 
-| Secret | Infra stack | S3 / CloudFront host (prod) |
+Configure these under **Settings → Secrets and variables → Actions → Variables** (not secrets).
+
+| Variable | Infra stack | S3 / CloudFront host (prod) |
 |--------|-------------|-----------------------------|
 | `EPHEMERAL_RUNNER_FORKED_INTERNAL_API_URL_PROD` | `ot2-internal-ci` | `ot2-development.builds.opentrons.com` |
 | `EPHEMERAL_RUNNER_FORKED_INTERNAL_API_URL_DEV` | `ot2-internal-ci` (dev workspace) | `ot2-development-dev.builds.opentrons.com` |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -123,12 +123,14 @@ jobs:
           RUNNER_LABEL: ephemeral-${{ github.run_id }}-${{ github.run_attempt }}
           MAX_ATTEMPTS: ${{ inputs.runner-request-max-attempts }}
           RETRY_SECONDS: ${{ inputs.runner-request-retry-seconds }}
-          EPHEMERAL_RUNNER_FORKED_INTERNAL_API_URL_DEV: ${{ secrets.EPHEMERAL_RUNNER_FORKED_INTERNAL_API_URL_DEV }}
-          EPHEMERAL_RUNNER_FORKED_INTERNAL_API_URL_PROD: ${{ secrets.EPHEMERAL_RUNNER_FORKED_INTERNAL_API_URL_PROD }}
-          EPHEMERAL_RUNNER_FORKED_RELEASE_API_URL_DEV: ${{ secrets.EPHEMERAL_RUNNER_FORKED_RELEASE_API_URL_DEV }}
-          EPHEMERAL_RUNNER_FORKED_RELEASE_API_URL_PROD: ${{ secrets.EPHEMERAL_RUNNER_FORKED_RELEASE_API_URL_PROD }}
-          EPHEMERAL_RUNNER_UNFORKED_API_URL_DEV: ${{ secrets.EPHEMERAL_RUNNER_UNFORKED_API_URL_DEV }}
-          EPHEMERAL_RUNNER_UNFORKED_API_URL_PROD: ${{ secrets.EPHEMERAL_RUNNER_UNFORKED_API_URL_PROD }}
+          # Repository variables (Settings → Secrets and variables → Actions → Variables).
+          # See .github/workflows/RUNNER_SECRETS.md for names and infra mapping.
+          EPHEMERAL_RUNNER_FORKED_INTERNAL_API_URL_DEV: ${{ vars.EPHEMERAL_RUNNER_FORKED_INTERNAL_API_URL_DEV }}
+          EPHEMERAL_RUNNER_FORKED_INTERNAL_API_URL_PROD: ${{ vars.EPHEMERAL_RUNNER_FORKED_INTERNAL_API_URL_PROD }}
+          EPHEMERAL_RUNNER_FORKED_RELEASE_API_URL_DEV: ${{ vars.EPHEMERAL_RUNNER_FORKED_RELEASE_API_URL_DEV }}
+          EPHEMERAL_RUNNER_FORKED_RELEASE_API_URL_PROD: ${{ vars.EPHEMERAL_RUNNER_FORKED_RELEASE_API_URL_PROD }}
+          EPHEMERAL_RUNNER_UNFORKED_API_URL_DEV: ${{ vars.EPHEMERAL_RUNNER_UNFORKED_API_URL_DEV }}
+          EPHEMERAL_RUNNER_UNFORKED_API_URL_PROD: ${{ vars.EPHEMERAL_RUNNER_UNFORKED_API_URL_PROD }}
         run: python3 "${{ github.workspace }}/initialize_runner.py"
 
   # Build job runs on ephemeral or static runner per initialize-infra

--- a/initialize_runner.py
+++ b/initialize_runner.py
@@ -19,7 +19,7 @@ def env_bool(name: str) -> bool:
 
 
 def api_url_for(resolution: str, infra_stage: str) -> tuple[str, str]:
-    """Return (api_url, missing_secret_message) for the given resolution."""
+    """Return (api_url, missing_variable_message) for the given resolution."""
     is_dev = infra_stage == "stage-dev"
     if resolution == "ephemeral-internal":
         url = os.environ.get(
@@ -28,7 +28,7 @@ def api_url_for(resolution: str, infra_stage: str) -> tuple[str, str]:
             "",
         ).strip()
         missing = (
-            "Missing EPHEMERAL_RUNNER_FORKED_INTERNAL_API_URL_* secret "
+            "Missing EPHEMERAL_RUNNER_FORKED_INTERNAL_API_URL_* repository variable "
             f"for infra-stage={infra_stage}"
         )
     elif resolution == "ephemeral-ot2-external":
@@ -38,7 +38,7 @@ def api_url_for(resolution: str, infra_stage: str) -> tuple[str, str]:
             "",
         ).strip()
         missing = (
-            "Missing EPHEMERAL_RUNNER_FORKED_RELEASE_API_URL_* secret "
+            "Missing EPHEMERAL_RUNNER_FORKED_RELEASE_API_URL_* repository variable "
             f"for infra-stage={infra_stage}"
         )
     elif resolution == "ephemeral-unforked":
@@ -48,7 +48,7 @@ def api_url_for(resolution: str, infra_stage: str) -> tuple[str, str]:
             "",
         ).strip()
         missing = (
-            "Missing EPHEMERAL_RUNNER_UNFORKED_API_URL_* secret "
+            "Missing EPHEMERAL_RUNNER_UNFORKED_API_URL_* repository variable "
             f"for infra-stage={infra_stage}"
         )
     else:


### PR DESCRIPTION
Move the six EPHEMERAL_RUNNER_*_API_URL values from Actions secrets to variables in initialize-infra and update initialize_runner.py messaging.