### PR TITLE
ci: tar.zst + fingerprint S3 cache for downloads/ccache

### DIFF
--- a/.github/scripts/s3-buildroot-cache.sh
+++ b/.github/scripts/s3-buildroot-cache.sh
@@ -1,0 +1,239 @@
+#!/usr/bin/env bash
+# Buildroot S3 cache for CI (downloads + ccache).
+#
+# Local trees (under <cachedir>/):
+#   downloads/   BR2_DL_DIR bind mount
+#   ccache/      BR2_CCACHE_DIR bind mount
+#
+# S3 objects (under <s3_prefix>/, typically .../ot2-br/):
+#   <type>.tar.zst     archive of that tree (tar + zstd; preserves empty dirs)
+#   <type>.manifest    sha256 of sorted "path + size" (+ empty dirs)
+#
+# Commands:
+#   pull  Download each .tar.zst that exists and extract into <cachedir>/<type>.
+#         Missing objects are skipped (cold / partial cache is fine).
+#   push  Fingerprint each local tree. If it matches the remote .manifest, skip.
+#         Otherwise archive to .tar.zst, upload it, and write .manifest.
+#
+# Busting: change tree contents so the fingerprint no longer matches .manifest,
+# or delete the S3 objects. First merge of this format expects a cache miss
+# (legacy .zip objects under the same prefix are ignored); the next successful
+# push publishes .tar.zst + .manifest.
+#
+# Requires zstd on PATH. Provision it on the ephemeral runner image — this
+# script does not install packages.
+set -euo pipefail
+
+CACHE_TYPES=(downloads ccache)
+
+log() {
+  echo "$@"
+}
+
+require_zstd() {
+  if ! command -v zstd >/dev/null 2>&1; then
+    log "ERROR: zstd is required but not on PATH. Install it on the ephemeral runner image." >&2
+    return 1
+  fi
+  zstd --version
+}
+
+# Fingerprint used to decide whether push can skip archive+upload.
+fingerprint_dir() {
+  local dir="$1"
+  if [[ ! -d "$dir" ]]; then
+    echo "missing"
+    return 0
+  fi
+  (
+    cd "$dir"
+    find . -type f -printf 'f %P %s\n' 2>/dev/null
+    find . -type d -empty -printf 'd %P\n' 2>/dev/null
+  ) | LC_ALL=C sort | sha256sum | awk '{print $1}'
+}
+
+s3_exists() {
+  local uri="$1"
+  aws s3api head-object \
+    --bucket "$(echo "$uri" | sed -E 's|^s3://([^/]+)/.*|\1|')" \
+    --key "$(echo "$uri" | sed -E 's|^s3://[^/]+/||')" \
+    >/dev/null 2>&1
+}
+
+s3_cp() {
+  aws s3 cp --no-progress "$@"
+}
+
+download_with_retries() {
+  local src="$1"
+  local dest="$2"
+  local max_attempts=3
+  local attempt=1
+  local rc=0
+  while true; do
+    log "Downloading ${src} (attempt ${attempt}/${max_attempts})"
+    if s3_cp "$src" "$dest"; then
+      return 0
+    fi
+    rc=$?
+    log "Download failed (exit ${rc})"
+    if [[ $attempt -ge $max_attempts ]]; then
+      return "$rc"
+    fi
+    sleep $((attempt * 15))
+    attempt=$((attempt + 1))
+  done
+}
+
+pull_all() {
+  local s3_prefix="$1"
+  local cachedir="$2"
+  require_zstd
+  mkdir -p "$cachedir"
+
+  local workdir
+  workdir="$(mktemp -d -t s3-cache-pull-XXXXXX)"
+  local -a pids=()
+  local -a types=()
+  local cachetype
+  local i=0
+
+  # Download in parallel; extract sequentially after joins.
+  for cachetype in "${CACHE_TYPES[@]}"; do
+    (
+      if s3_exists "${s3_prefix}/${cachetype}.tar.zst"; then
+        download_with_retries "${s3_prefix}/${cachetype}.tar.zst" "${workdir}/${cachetype}.tar.zst"
+        log "Fetched ${cachetype}.tar.zst ($(du -h "${workdir}/${cachetype}.tar.zst" | cut -f1)B)"
+        exit 0
+      fi
+      log "No ${cachetype}.tar.zst in S3; skipping"
+      exit 1
+    ) &
+    pids+=($!)
+    types+=("$cachetype")
+  done
+
+  local -a fetched=()
+  for i in "${!pids[@]}"; do
+    if wait "${pids[$i]}"; then
+      fetched+=("${types[$i]}")
+    fi
+  done
+
+  if [[ ${#fetched[@]} -eq 0 ]]; then
+    log "WARNING: no cache archives downloaded; Buildroot will be a cold build for downloads/ccache"
+    rm -rf "$workdir"
+    return 0
+  fi
+
+  for cachetype in "${fetched[@]}"; do
+    local dest="${cachedir}/${cachetype}"
+    local archive="${workdir}/${cachetype}.tar.zst"
+    mkdir -p "$dest"
+    log "Extracting ${cachetype} -> ${dest}"
+    zstd -d -T0 -c "$archive" | tar -C "$dest" -xf -
+    rm -f "$archive"
+    log "Extracted ${cachetype}: $(du -sh "$dest" | cut -f1)"
+  done
+
+  rm -rf "$workdir"
+}
+
+push_one() {
+  local s3_prefix="$1"
+  local cachedir="$2"
+  local cachetype="$3"
+  local thiscache="${cachedir}/${cachetype}"
+  local archive="${cachedir}/../${cachetype}.tar.zst"
+  local manifest_remote="${s3_prefix}/${cachetype}.manifest"
+  local local_fp remote_fp
+
+  if [[ ! -d "$thiscache" ]]; then
+    log "No local directory for ${cachetype}; skipping"
+    return 0
+  fi
+
+  local file_count
+  file_count=$(find "$thiscache" -type f 2>/dev/null | wc -l | tr -d ' ')
+  log "Cache ${cachetype}: ${file_count} files, $(du -sh "$thiscache" | cut -f1)"
+  if [[ "$file_count" -eq 0 ]]; then
+    log "Cache ${cachetype} empty; skipping"
+    return 0
+  fi
+
+  log "Fingerprinting ${cachetype}"
+  local_fp="$(fingerprint_dir "$thiscache")"
+  log "Local fingerprint: ${local_fp}"
+
+  remote_fp=""
+  if remote_fp="$(aws s3 cp --no-progress "$manifest_remote" - 2>/dev/null)"; then
+    remote_fp="$(echo -n "$remote_fp" | tr -d '[:space:]')"
+    log "Remote fingerprint: ${remote_fp}"
+  else
+    log "No remote manifest for ${cachetype}"
+  fi
+
+  if [[ -n "$remote_fp" && "$local_fp" == "$remote_fp" ]]; then
+    log "Skipping ${cachetype}: fingerprint unchanged"
+    return 0
+  fi
+
+  log "Archiving ${cachetype} -> ${archive}"
+  rm -f "$archive"
+  tar -C "$thiscache" -cf - . | zstd -T0 -3 -q -o "$archive"
+  log "Archived ${cachetype}: $(du -h "$archive" | cut -f1)B"
+
+  log "Uploading ${cachetype}.tar.zst"
+  s3_cp "$archive" "${s3_prefix}/${cachetype}.tar.zst"
+  echo -n "$local_fp" | s3_cp - "$manifest_remote"
+  log "Wrote ${cachetype}.manifest"
+
+  rm -f "$archive"
+}
+
+push_all() {
+  local s3_prefix="$1"
+  local cachedir="$2"
+  require_zstd
+
+  if [[ -d "$cachedir" ]]; then
+    sudo chown -R "$(id -u):$(id -g)" "$cachedir" || true
+  fi
+
+  local cachetype
+  for cachetype in "${CACHE_TYPES[@]}"; do
+    push_one "$s3_prefix" "$cachedir" "$cachetype"
+  done
+}
+
+usage() {
+  cat <<EOF
+Usage:
+  $0 require-zstd
+  $0 pull <s3_prefix> <cachedir>
+  $0 push <s3_prefix> <cachedir>
+EOF
+}
+
+main() {
+  local cmd="${1:-}"
+  case "$cmd" in
+    require-zstd)
+      require_zstd
+      ;;
+    pull)
+      if [[ $# -ne 3 ]]; then usage; exit 1; fi
+      pull_all "$2" "$3"
+      ;;
+    push)
+      if [[ $# -ne 3 ]]; then usage; exit 1; fi
+      push_all "$2" "$3"
+      ;;
+    *)
+      usage
+      exit 1
+      ;;
+  esac
+}
+
+main "$@"

--- a/.github/workflows/RUNNER_SECRETS.md
+++ b/.github/workflows/RUNNER_SECRETS.md
@@ -10,3 +10,12 @@ Workflow: `build.yml` job `initialize-infra` runs `initialize_runner.py`, which 
 | `EPHEMERAL_RUNNER_FORKED_RELEASE_API_URL_DEV` | `ot2-ci` (dev workspace) | `ot2-dev.builds.opentrons.com` |
 | `EPHEMERAL_RUNNER_UNFORKED_API_URL_PROD` | `release-ci` / merged stack | `builds.opentrons.com` |
 | `EPHEMERAL_RUNNER_UNFORKED_API_URL_DEV` | `release-ci` (dev) | `dev.builds.opentrons.com` |
+
+## Buildroot S3 downloads / ccache cache
+
+CI uses runner env `S3_CACHE_ARN` and `LOCAL_CACHE`. Helper: [`.github/scripts/s3-buildroot-cache.sh`](../scripts/s3-buildroot-cache.sh).
+
+- Trees: `downloads` (`BR2_DL_DIR`), `ccache` (`BR2_CCACHE_DIR`) under `LOCAL_CACHE`.
+- Objects under `s3://…/ot2-br/`: `<type>.tar.zst` + `<type>.manifest` (fingerprint skip on push).
+- **Pull** is skipped if that prefix is already &gt; 50 GB. **Push** runs after artifact/release upload; **poisoned cache** wipe on job failure.
+- Requires **zstd** on the ephemeral runner image. Legacy `ot2-br/*.zip` objects are ignored; first run after merge cold-misses until a successful push seeds the new format.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -210,36 +210,34 @@ jobs:
         run: |
           set -euo pipefail
 
-          aws_cp="aws --profile=${{ steps.aws.outputs.profile_name }} s3 cp --no-progress"
+          cache_script=./buildroot-for-workflow/.github/scripts/s3-buildroot-cache.sh
+          chmod +x "$cache_script"
           cachedir="${LOCAL_CACHE:-./cache}"
           cache_prefix=ot2-br
+          s3_prefix="s3://${S3_CACHE_ARN/arn:aws:s3:::/}/${cache_prefix}"
 
+          # Skip pull if the ot2-br cache prefix is already huge so we keep room to build.
+          sizeInBytes=$(aws s3 ls "${s3_prefix}/" --recursive --summarize 2>/dev/null | awk 'END{print}' | grep -o '[0-9].*' || echo 0)
+          sizeInGigabytes=$((sizeInBytes/1024/1024/1024))
+          if [[ $sizeInGigabytes -gt 50 ]]; then
+            echo "Doing clean build without cache pull; size of ${cache_prefix}/ cache: ${sizeInGigabytes}GB"
+          else
+            "$cache_script" pull "$s3_prefix" "$cachedir"
+          fi
+
+          here=$(pwd)
           for cachetype in downloads ccache ; do
             thiscache="${cachedir}/${cachetype}"
-            localzip="${cachedir}/../${cache_prefix}-${cachetype}.zip"
-            remotezip="s3://${S3_CACHE_ARN/arn:aws:s3:::/}/${cache_prefix}/${cachetype}.zip"
-
             mkdir -p "${thiscache}"
             echo "${cachetype}=${thiscache}" >> "$GITHUB_OUTPUT"
-            here=$(pwd)
             reldir=$(realpath --relative-to="${here}" "${thiscache}")
             echo "Created ${cachetype} cache at ${thiscache} (${reldir})"
             echo "${cachetype}-rel=${reldir}" >> "$GITHUB_OUTPUT"
-
-            echo "Fetching cache ${remotezip} -> ${localzip}"
-            if ${aws_cp} "${remotezip}" "${localzip}" ; then
-              echo "Extracting ${localzip} -> ${thiscache}"
-              unzip -q -u -o "${localzip}" -d "${thiscache}"
-              rm -f "${localzip}"
-            else
-              echo "No cache found at ${remotezip} (continuing)"
-            fi
           done
 
           outputdir="${cachedir}/output"
           mkdir -p "${outputdir}"
           echo "output=${outputdir}" >> "$GITHUB_OUTPUT"
-          here=$(pwd)
           output_reldir=$(realpath --relative-to=${here} "${outputdir}")
           echo "Created output dir at ${outputdir} (${output_reldir})"
           echo "output-rel=${output_reldir}" >> "$GITHUB_OUTPUT"
@@ -347,41 +345,6 @@ jobs:
         run: |
           cd buildroot
           docker run ${{steps.docker-args.outputs.args}} all
-      - name: Push S3 cache
-        if: success()
-        shell: bash
-        continue-on-error: true
-        run: |
-          set -euo pipefail
-
-          aws_cp="aws --profile=${{ steps.aws.outputs.profile_name }} s3 cp --no-progress"
-          cachedir=${LOCAL_CACHE:-./cache}
-          cache_prefix=ot2-br
-
-          for cachetype in downloads ccache ; do
-            thiscache="${cachedir}/${cachetype}"
-            localzip="${cachedir}/../${cache_prefix}-${cachetype}.zip"
-            remotezip="s3://${S3_CACHE_ARN/arn:aws:s3:::/}/${cache_prefix}/${cachetype}.zip"
-
-            if [ ! -d "${thiscache}" ]; then
-              echo "Cache dir ${thiscache} does not exist; skipping upload"
-              continue
-            fi
-
-            # Docker bind mounts often leave root-owned files; zip cannot read them otherwise.
-            sudo chown -R "$(id -u):$(id -g)" "${thiscache}"
-
-            df -h || true
-            echo "Refreshing cache for ${cachetype} from ${thiscache} -> ${localzip}"
-            rm -f "${localzip}"
-            pushd "${thiscache}" >/dev/null
-            zip -q -r --filesync --symlinks "${localzip}" ./*
-            popd >/dev/null
-
-            echo "Uploading ${localzip} -> ${remotezip}"
-            ${aws_cp} "${localzip}" "${remotezip}"
-            rm -f "${localzip}"
-          done
       - name: Upload build log result
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
@@ -588,7 +551,34 @@ jobs:
           artifactContentType: application/json
           token: ${{ steps.ot2-app-token.outputs.token }}
 
-      # Ephemeral runners are destroyed after the job, so no cleanup needed.
+      # Defer cache upload until after S3 artifact and monorepo release uploads so
+      # build outputs are published before this slow archive-and-upload step.
+      # Writes <type>.tar.zst + <type>.manifest under ot2-br/; skips when unchanged.
+      - name: Push S3 cache
+        if: success()
+        shell: bash
+        continue-on-error: true
+        run: |
+          set -euo pipefail
+          cache_script=./buildroot-for-workflow/.github/scripts/s3-buildroot-cache.sh
+          chmod +x "$cache_script"
+          cachedir=${LOCAL_CACHE:-./cache}
+          s3_prefix="s3://${S3_CACHE_ARN/arn:aws:s3:::/}/ot2-br"
+          df -h || true
+          "$cache_script" push "$s3_prefix" "$cachedir"
+      - name: Remove poisoned cache
+        if: failure()
+        shell: bash
+        continue-on-error: true
+        run: |
+          cachedir="${LOCAL_CACHE:-./cache}"
+          if [ -d "$cachedir" ]; then
+            sudo chown -R "$(id -u):$(id -g)" "$cachedir"
+            # Some cache entries can remain undeletable by the runner user; remove as root.
+            sudo rm -rf "${cachedir}/"* "${cachedir}"/.[!.]* "${cachedir}"/..?* 2>/dev/null || true
+          fi
+
+      # Ephemeral runners are destroyed after the job, so no further cleanup needed.
 
   notify-tagged-success:
     name: 'Notify Tagged Build Success'


### PR DESCRIPTION
## Summary
- Port the oe-core S3 cache helper pattern into `.github/scripts/s3-buildroot-cache.sh` for Buildroot `downloads` (`BR2_DL_DIR`) and `ccache` (`BR2_CCACHE_DIR`).
- Pull archives in parallel; push only when the tree fingerprint changes; skip pull when the `ot2-br/` prefix is already >50 GB.
- Defer cache push until after artifact/release upload, and wipe poisoned local cache on job failure.

## Test plan
- [ ] Confirm ephemeral runners have `zstd` on PATH
- [ ] Run a cold build (expect miss on new `.tar.zst` objects; legacy `.zip` ignored)
- [ ] Confirm successful push publishes `ot2-br/downloads.tar.zst` + `.manifest` and `ot2-br/ccache.tar.zst` + `.manifest`
- [ ] Re-run with unchanged caches and verify push skips on fingerprint match
- [ ] Confirm artifacts/releases still upload when cache push is slow/fails (`continue-on-error`)


Made with [Cursor](https://cursor.com)