### PR TITLE
ci: STEP 2: skip S3 cache pull when ot2-br prefix exceeds 50GB

### DIFF
--- a/.github/workflows/RUNNER_SECRETS.md
+++ b/.github/workflows/RUNNER_SECRETS.md
@@ -17,4 +17,5 @@ CI uses runner env `S3_CACHE_ARN` and `LOCAL_CACHE`. Helper: [`.github/scripts/s
 
 - Trees: `downloads` (`BR2_DL_DIR`), `ccache` (`BR2_CCACHE_DIR`) under `LOCAL_CACHE`.
 - Objects under `s3://…/ot2-br/`: `<type>.tar.zst` + `<type>.manifest` (fingerprint skip on push).
+- **Pull** is skipped if that prefix is already > 50 GB.
 - Requires **zstd** on the ephemeral runner image. Legacy `ot2-br/*.zip` objects are ignored; first run after merge cold-misses until a successful push seeds the new format.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -216,7 +216,14 @@ jobs:
           cache_prefix=ot2-br
           s3_prefix="s3://${S3_CACHE_ARN/arn:aws:s3:::/}/${cache_prefix}"
 
-          "$cache_script" pull "$s3_prefix" "$cachedir"
+          # Skip pull if the ot2-br cache prefix is already huge so we keep room to build.
+          sizeInBytes=$(aws s3 ls "${s3_prefix}/" --recursive --summarize 2>/dev/null | awk 'END{print}' | grep -o '[0-9].*' || echo 0)
+          sizeInGigabytes=$((sizeInBytes/1024/1024/1024))
+          if [[ $sizeInGigabytes -gt 50 ]]; then
+            echo "Doing clean build without cache pull; size of ${cache_prefix}/ cache: ${sizeInGigabytes}GB"
+          else
+            "$cache_script" pull "$s3_prefix" "$cachedir"
+          fi
 
           here=$(pwd)
           for cachetype in downloads ccache ; do


### PR DESCRIPTION
## Summary
- Skip downloading the Buildroot S3 cache when the `ot2-br/` prefix is already larger than 50 GB so the runner keeps disk for the build.

## Stack
Depends on the tar.zst helper PR (`feat/ci-s3-cache-tar-zst`).

## Test plan
- [ ] With a small cache prefix, pull still runs
- [ ] With a large prefix (or simulated), logs skip pull and build continues cold for downloads/ccache