### PR TITLE
ci: STEP 3: defer S3 cache push until after artifact uploads

### DIFF
--- a/.github/workflows/RUNNER_SECRETS.md
+++ b/.github/workflows/RUNNER_SECRETS.md
@@ -18,4 +18,5 @@ CI uses runner env `S3_CACHE_ARN` and `LOCAL_CACHE`. Helper: [`.github/scripts/s
 - Trees: `downloads` (`BR2_DL_DIR`), `ccache` (`BR2_CCACHE_DIR`) under `LOCAL_CACHE`.
 - Objects under `s3://…/ot2-br/`: `<type>.tar.zst` + `<type>.manifest` (fingerprint skip on push).
 - **Pull** is skipped if that prefix is already > 50 GB.
+- **Push** runs after artifact/release upload.
 - Requires **zstd** on the ephemeral runner image. Legacy `ot2-br/*.zip` objects are ignored; first run after merge cold-misses until a successful push seeds the new format.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -345,18 +345,6 @@ jobs:
         run: |
           cd buildroot
           docker run ${{steps.docker-args.outputs.args}} all
-      - name: Push S3 cache
-        if: success()
-        shell: bash
-        continue-on-error: true
-        run: |
-          set -euo pipefail
-          cache_script=./buildroot-for-workflow/.github/scripts/s3-buildroot-cache.sh
-          chmod +x "$cache_script"
-          cachedir=${LOCAL_CACHE:-./cache}
-          s3_prefix="s3://${S3_CACHE_ARN/arn:aws:s3:::/}/ot2-br"
-          df -h || true
-          "$cache_script" push "$s3_prefix" "$cachedir"
       - name: Upload build log result
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
@@ -562,6 +550,22 @@ jobs:
           artifacts: "${{steps.artifact-copy.outputs.versioned_artifact_dir_rel}}/VERSION-*.json"
           artifactContentType: application/json
           token: ${{ steps.ot2-app-token.outputs.token }}
+
+      # Defer cache upload until after S3 artifact and monorepo release uploads so
+      # build outputs are published before this slow archive-and-upload step.
+      # Writes <type>.tar.zst + <type>.manifest under ot2-br/; skips when unchanged.
+      - name: Push S3 cache
+        if: success()
+        shell: bash
+        continue-on-error: true
+        run: |
+          set -euo pipefail
+          cache_script=./buildroot-for-workflow/.github/scripts/s3-buildroot-cache.sh
+          chmod +x "$cache_script"
+          cachedir=${LOCAL_CACHE:-./cache}
+          s3_prefix="s3://${S3_CACHE_ARN/arn:aws:s3:::/}/ot2-br"
+          df -h || true
+          "$cache_script" push "$s3_prefix" "$cachedir"
 
       # Ephemeral runners are destroyed after the job, so no cleanup needed.
 


### PR DESCRIPTION
## Summary
- Move cache push to after S3 artifact / monorepo release uploads so slow archive+upload cannot delay publishing build outputs.

## Stack
Depends on the size-gate PR (`feat/ci-s3-cache-size-gate`).

## Test plan
- [ ] Confirm Push S3 cache step runs after artifact/release steps
- [ ] Confirm artifacts still publish if cache push is slow/fails (`continue-on-error`)