### PR TITLE
ci: STEP 4: wipe LOCAL_CACHE on build failure

### DIFF
--- a/.github/workflows/RUNNER_SECRETS.md
+++ b/.github/workflows/RUNNER_SECRETS.md
@@ -19,4 +19,5 @@ CI uses runner env `S3_CACHE_ARN` and `LOCAL_CACHE`. Helper: [`.github/scripts/s
 - Objects under `s3://…/ot2-br/`: `<type>.tar.zst` + `<type>.manifest` (fingerprint skip on push).
 - **Pull** is skipped if that prefix is already > 50 GB.
 - **Push** runs after artifact/release upload.
+- **Poisoned cache** wipe on job failure.
 - Requires **zstd** on the ephemeral runner image. Legacy `ot2-br/*.zip` objects are ignored; first run after merge cold-misses until a successful push seeds the new format.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -566,8 +566,19 @@ jobs:
           s3_prefix="s3://${S3_CACHE_ARN/arn:aws:s3:::/}/ot2-br"
           df -h || true
           "$cache_script" push "$s3_prefix" "$cachedir"
+      - name: Remove poisoned cache
+        if: failure()
+        shell: bash
+        continue-on-error: true
+        run: |
+          cachedir="${LOCAL_CACHE:-./cache}"
+          if [ -d "$cachedir" ]; then
+            sudo chown -R "$(id -u):$(id -g)" "$cachedir"
+            # Some cache entries can remain undeletable by the runner user; remove as root.
+            sudo rm -rf "${cachedir}/"* "${cachedir}"/.[!.]* "${cachedir}"/..?* 2>/dev/null || true
+          fi
 
-      # Ephemeral runners are destroyed after the job, so no cleanup needed.
+      # Ephemeral runners are destroyed after the job, so no further cleanup needed.
 
   notify-tagged-success:
     name: 'Notify Tagged Build Success'


### PR DESCRIPTION
## Summary
- On job failure, clear `LOCAL_CACHE` downloads/ccache so the next run on the same runner does not reuse a poisoned cache.

## Stack
Depends on the defer-push PR (`feat/ci-s3-cache-defer-push`). Final tip of the stack.

## Test plan
- [ ] Failed build clears local cache dirs
- [ ] Successful builds leave cache in place for push