### PR TITLE
fix(ot2): read VERSION.json git metadata from overlay repo

### DIFF
--- a/board/opentrons/ot2/write_version.py
+++ b/board/opentrons/ot2/write_version.py
@@ -11,7 +11,12 @@ def buildroot_repo_dir() -> str:
     if overlay_path:
         return overlay_path
     # Local/dev fallback when BR2_EXTERNAL is not exported.
-    return os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
+    fallback = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
+    print(
+        'BR2_EXTERNAL_OPENTRONS_BUILDROOT_OVERLAYS_PATH not set; '
+        f'defaulting to local path {fallback}'
+    )
+    return fallback
 
 
 def git_output(repo_dir: str, *args: str) -> str:

--- a/board/opentrons/ot2/write_version.py
+++ b/board/opentrons/ot2/write_version.py
@@ -4,28 +4,42 @@ import sys
 import subprocess
 import argparse
 
+
+def buildroot_repo_dir() -> str:
+    """Return the Opentrons buildroot overlay repo, not upstream buildroot."""
+    overlay_path = os.getenv('BR2_EXTERNAL_OPENTRONS_BUILDROOT_OVERLAYS_PATH', '').strip()
+    if overlay_path:
+        return overlay_path
+    # Local/dev fallback when BR2_EXTERNAL is not exported.
+    return os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
+
+
+def git_output(repo_dir: str, *args: str) -> str:
+    return subprocess.check_output(
+        ['git', '-C', repo_dir, *args],
+        stderr=subprocess.STDOUT,
+    ).decode().strip()
+
+
+buildroot_repo = buildroot_repo_dir()
+print(f"Reading buildroot git metadata from {buildroot_repo}")
+
 try:
-    br_version = subprocess.check_output(
-        ['git', 'describe', '--tags', '--always'],
-        stderr=subprocess.STDOUT).decode().strip()
+    br_version = git_output(buildroot_repo, 'describe', '--tags', '--always')
 except subprocess.CalledProcessError as cpe:
     print("{}: {}: {}".format(cpe.cmd, cpe.returncode, cpe.stdout))
     print("Defaulting to (unknown)")
     br_version = 'unknown'
 
 try:
-    br_sha = subprocess.check_output(
-        ['git', 'rev-parse', 'HEAD'],
-        stderr=subprocess.STDOUT).decode().strip()
+    br_sha = git_output(buildroot_repo, 'rev-parse', 'HEAD')
 except subprocess.CalledProcessError as cpe:
     print("{}: {}: {}".format(cpe.cmd, cpe.returncode, cpe.stdout))
     print("Defaulting to (unknown)")
     br_sha = 'unknown'
 
 try:
-    br_branch_from_git = subprocess.check_output(
-        ['git', 'rev-parse', '--abbrev-ref', 'HEAD'],
-        stderr=subprocess.STDOUT).decode().strip()
+    br_branch_from_git = git_output(buildroot_repo, 'rev-parse', '--abbrev-ref', 'HEAD')
 except subprocess.CalledProcessError as cpe:
     print("{}: {}: {}".format(cpe.cmd, cpe.returncode, cpe.stdout))
     print("Defaulting to (unknown)")


### PR DESCRIPTION
## Overview

After the BR2_EXTERNAL overlay migration (`2b2b23d35e`, 2025-10-24), `VERSION.json` was recording the wrong buildroot commit. `write_version.py` ran bare `git rev-parse HEAD` in the build working directory, which is upstream buildroot at `/buildroot`, not the Opentrons overlay at `/buildroot-overlays`.

Before that migration, this was correct: Opentrons/buildroot was the buildroot tree and `make` ran in that repo. The external-tree refactor updated `post-build.sh` to invoke the script from `BR2_EXTERNAL_OPENTRONS_BUILDROOT_OVERLAYS_PATH`, but never updated `write_version.py` to read git metadata from that path. Any CI or local build using the overlay layout since October 2025 would have written upstream buildroot's SHA/tag into `buildroot_sha`, `buildroot_version`, and `buildroot_branch`.

This PR runs all git commands with `git -C` against the overlay repo (`BR2_EXTERNAL_OPENTRONS_BUILDROOT_OVERLAYS_PATH`, with a script-location fallback for local dev).

**Acceptance criteria:**
- `VERSION.json` `buildroot_sha` matches the Opentrons/buildroot commit checked out for the build
- `buildroot_version` reflects Opentrons release tags (e.g. `v1.19.10`, `internal@…`), not upstream buildroot (e.g. `2025.02.7`)

## Test Plan and Hands on Testing

- [x] Ran `write_version.py` with `BR2_EXTERNAL_OPENTRONS_BUILDROOT_OVERLAYS_PATH` set while CWD was a fake upstream directory; confirmed `buildroot_sha` and `buildroot_version` came from the Opentrons overlay repo
- [ ] Verify on next CI build that published `VERSION.json` `buildroot_sha` matches the buildroot ref resolved by `build-refs`

## Changelog

- Fix `VERSION.json` recording upstream buildroot git metadata instead of Opentrons/buildroot after the external-tree migration

## Review requests

- Confirm `BR2_EXTERNAL_OPENTRONS_BUILDROOT_OVERLAYS_PATH` is always set when `post-build.sh` runs in CI (it should be, since buildroot exports it for external trees)

## Risk assessment

- **Attention level:** low
- Single-file change to version metadata collection; no build logic or packaging changes
- Fallback to script-relative repo root preserves local/dev behavior when the env var is absent