### PR TITLE
fix(ci): always build OT-2 images from opentrons-ot2

### DIFF
--- a/.github/actions/build-refs/action.yml
+++ b/.github/actions/build-refs/action.yml
@@ -5,7 +5,7 @@ inputs:
     description: "gh token for api calls to resolve refs"
     required: true
   monorepo:
-    description: "ref of https://github.com/opentrons/opentrons to build"
+    description: "ref of https://github.com/opentrons/opentrons-ot2 to build"
     required: false
     default: "-"
   buildroot:
@@ -13,9 +13,9 @@ inputs:
     required: false
     default: "-"
   monorepo-repo:
-    description: "repo name for the monorepo (i.e. opentrons or opentrons-ot2)"
+    description: "repo name for the monorepo (opentrons-ot2)"
     required: false
-    default: "opentrons"
+    default: "opentrons-ot2"
 outputs:
   monorepo:
     description: "the ref of the monorepo to use"
@@ -26,7 +26,7 @@ outputs:
   variant:
     description: "Which variant to build (release, internal-release)"
   monorepo-repo:
-    description: "Which repository under Opentrons to use for the monorepo (opentrons, opentrons-ot2)"
+    description: "OT-2 builds always use opentrons-ot2"
 runs:
   using: 'node16'
   main: 'dist/index.js'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,16 +5,10 @@ on:
     inputs:
       monorepo-ref:
         description: |
-          Ref of https://github.com/opentrons/opentrons or https://github.com/opentrons/opentrons-ot2 to build. This MUST be a full ref, e.g. refs/heads/edge, or '-' to indicate not-specified. If not specified, will be determined from the oe-core ref if specified, and then default to edge.
+          Ref of https://github.com/opentrons/opentrons-ot2 to build. This MUST be a full ref, e.g. refs/heads/edge, or '-' to indicate not-specified. If not specified, will be determined from the buildroot ref if specified, and then default to edge.
         required: true
         default: '-'
         type: string
-      monorepo-is-fork:
-        description: |
-          Whether the monorepo-ref refers to https://github.com/opentrons/opentrons (false, the default) or https://github.com/opentrons/opentrons-ot2 (true, must be explicitly selected)
-        required: false
-        default: false
-        type: boolean
       buildroot-ref:
         description: |
           Ref of https://github.com/opentrons/buildroot to build. This is different from the ref specified in the github api/webUI when starting this workflow - that ref is what contains this workflow, this ref specifies what gets built. It MUST be a full ref, e.g. refs/heads/main, or '-' to indicate not-specified. If not specified, will be decided based on the monorepo ref; if that isn't specified, will be main.
@@ -86,7 +80,7 @@ jobs:
           token: ${{ github.token }}
           monorepo: ${{ inputs.monorepo-ref }}
           buildroot: ${{ inputs.buildroot-ref }}
-          monorepo-repo: ${{ case(inputs.monorepo-is-fork, 'opentrons-ot2', 'opentrons')}}
+          monorepo-repo: opentrons-ot2
       - name: Add refs to the summary
         run: |
           echo "### Decide refs" >> "$GITHUB_STEP_SUMMARY"
@@ -116,10 +110,8 @@ jobs:
         name: Initialize runner
         env:
           FORCE_EPHEMERAL: ${{ inputs.force-ephemeral-infra }}
-          MONOREPO_IS_FORK: ${{ inputs.monorepo-is-fork }}
           VARIANT: ${{ needs.decide-refs.outputs.variant }}
           INFRA_STAGE: ${{ inputs.infra-stage }}
-          MONOREPO_REPO: ${{ needs.decide-refs.outputs.monorepo-repo }}
           RUNNER_LABEL: ephemeral-${{ github.run_id }}-${{ github.run_attempt }}
           MAX_ATTEMPTS: ${{ inputs.runner-request-max-attempts }}
           RETRY_SECONDS: ${{ inputs.runner-request-retry-seconds }}

--- a/initialize_runner.py
+++ b/initialize_runner.py
@@ -57,19 +57,13 @@ def api_url_for(resolution: str, infra_stage: str) -> tuple[str, str]:
     return url, missing
 
 
-def resolve_kind(
-    force_ephemeral: bool, is_fork: bool, variant: str
-) -> tuple[str, str | None]:
+def resolve_kind(force_ephemeral: bool, variant: str) -> tuple[str, str | None]:
     """Return (resolution, request_kind) where request_kind labels the API call."""
-    if not force_ephemeral and not is_fork:
-        return "static", None
     if variant == "internal-release":
         return "ephemeral-internal", "ot2-internal"
-    if is_fork:
-        return "ephemeral-ot2-external", "ot2-external"
     if force_ephemeral:
         return "ephemeral-unforked", "unforked"
-    return "unknown", None
+    return "ephemeral-ot2-external", "ot2-external"
 
 
 def request_ephemeral_runner(
@@ -187,41 +181,29 @@ def request_ephemeral_runner(
 
 def main() -> None:
     force_ephemeral = env_bool("FORCE_EPHEMERAL")
-    is_fork = env_bool("MONOREPO_IS_FORK")
     variant = os.environ["VARIANT"]
     infra_stage = os.environ["INFRA_STAGE"]
-    monorepo_repo = os.environ["MONOREPO_REPO"]
     runner_label = os.environ["RUNNER_LABEL"]
     max_attempts = int(os.environ.get("MAX_ATTEMPTS", "120"))
     retry_seconds = int(os.environ.get("RETRY_SECONDS", "60"))
 
-    resolution, request_kind = resolve_kind(force_ephemeral, is_fork, variant)
+    resolution, request_kind = resolve_kind(force_ephemeral, variant)
 
-    if resolution == "unknown":
-        print("Could not resolve runner configuration from inputs", file=sys.stderr)
+    api_url, missing_message = api_url_for(resolution, infra_stage)
+    if not api_url:
+        print(missing_message, file=sys.stderr)
         raise SystemExit(1)
-
-    if resolution == "static":
-        runner_labels = json.dumps(["self-hosted", infra_stage, variant])
-    else:
-        api_url, missing_message = api_url_for(resolution, infra_stage)
-        if not api_url:
-            print(missing_message, file=sys.stderr)
-            raise SystemExit(1)
-        runner_labels = request_ephemeral_runner(
-            api_url=api_url,
-            request_kind=request_kind or resolution,
-            infra_stage=infra_stage,
-            variant=variant,
-            runner_label=runner_label,
-            max_attempts=max_attempts,
-            retry_seconds=retry_seconds,
-        )
-
-    use_ephemeral_group = force_ephemeral or monorepo_repo == "opentrons-ot2"
-    runner_group = (
-        "ephemeral-system-builders" if use_ephemeral_group else "Custom Runners"
+    runner_labels = request_ephemeral_runner(
+        api_url=api_url,
+        request_kind=request_kind or resolution,
+        infra_stage=infra_stage,
+        variant=variant,
+        runner_label=runner_label,
+        max_attempts=max_attempts,
+        retry_seconds=retry_seconds,
     )
+
+    runner_group = "ephemeral-system-builders"
 
     write_output("runner_labels", runner_labels)
     write_output("runner_group", runner_group)


### PR DESCRIPTION
## Overview

OT-2 buildroot CI had a `monorepo-is-fork` workflow input (default `false`) that selected which app repo to build. With the default, manual dispatches and kickoffs checked out `Opentrons/opentrons` (Flex) instead of `Opentrons/opentrons-ot2`. Example: buildroot run 29224819360 showed `monorepo-repo: opentrons` in "Decide refs to build".

This PR removes that ambiguity entirely. OT-2 buildroot builds always use `opentrons-ot2`.

**Acceptance criteria:**
- No `monorepo-is-fork` input or related env vars in buildroot CI
- `decide-refs` always resolves `monorepo-repo: opentrons-ot2`
- Runner initialization always uses ephemeral builders (no static self-hosted fallback tied to fork state)

**Follow-up (separate PR in opentrons-ot2):** remove `"monorepo-is-fork": true` from `start-ot2-build.yaml` push kickoff after this merges.

## Test Plan and Hands on Testing

- [x] `rg` confirms zero matches for `monorepo-is-fork`, `MONOREPO_IS_FORK`, and `case(inputs.monorepo-is-fork`
- [x] `python3 -m py_compile initialize_runner.py`
- [ ] Manual workflow dispatch with defaults (`monorepo-ref: -`, `buildroot-ref: refs/heads/<branch>`) shows:
  - `monorepo-repo: opentrons-ot2` in decide-refs summary
  - Fetch step: `repository: Opentrons/opentrons-ot2`

## Changelog

- **CI:** Removed `monorepo-is-fork` workflow input from OT-2 build workflow; app source is always `opentrons-ot2`.
- **CI:** `build-refs` action default `monorepo-repo` changed from `opentrons` to `opentrons-ot2`.
- **CI:** `initialize_runner.py` always requests ephemeral runners and uses `ephemeral-system-builders` runner group.
- **Breaking:** Workflows or kickoffs that pass `monorepo-is-fork` will need that input removed (e.g. opentrons-ot2 `start-ot2-build.yaml`).

## Review requests

- Confirm runner resolution order in `initialize_runner.py` matches expected OT-2 infra: `internal-release` → internal API, `force-ephemeral-infra` → unforked API, else external API.
- Sanity-check that hardcoding `monorepo-repo: opentrons-ot2` in `build.yml` is sufficient without rebuilding `build-refs/dist/index.js`.

## Risk assessment

- **Attention level:** medium. Touches CI ref resolution and runner provisioning for all OT-2 image builds.
- **Trade-offs:** Removes the (incorrect) path that built OT-2 images from Flex `opentrons`; any workflow still passing `monorepo-is-fork` will fail until updated.
- **Blast radius:** OT-2 buildroot GitHub Actions only; checkout path `./opentrons` unchanged.
- **Mitigation:** Defaults now match the intended OT-2 app repo; companion opentrons-ot2 kickoff cleanup is a small follow-up.