### PR TITLE
ci: bump actions/checkout v3 pins to v4.3.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,7 +70,7 @@ jobs:
       monorepo-repo: ${{ steps.build-refs.outputs.monorepo-repo }}
     steps:
       - name: Check out sources for action
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           path: ./buildroot-for-workflow
       - name: Get the refs
@@ -160,12 +160,12 @@ jobs:
           apply_sysctl fs.inotify.max_user_instances 1280
           apply_sysctl fs.file-max 100000
       - name: Fetch initial sources for action
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
           path: ./buildroot-for-workflow
       - name: Fetch buildroot source
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
           ref: ${{needs.decide-refs.outputs.buildroot}}
@@ -178,7 +178,7 @@ jobs:
           fi
       - name: Fetch monorepo source
         id: monorepo-checkout
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
           ref: ${{ needs.decide-refs.outputs.monorepo }}
@@ -589,7 +589,7 @@ jobs:
     if: always() && inputs.infra-stage == 'stage-prod' && startsWith(needs.decide-refs.outputs.monorepo, 'refs/tags/') && needs.run-build.result == 'success'
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: 'Send success alert'
         uses: ./.github/actions/simple-build-alert
         continue-on-error: true
@@ -612,7 +612,7 @@ jobs:
     if: always() && inputs.infra-stage == 'stage-prod' && startsWith(needs.decide-refs.outputs.monorepo, 'refs/tags/') && needs.run-build.result == 'failure'
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: 'Send failure alert'
         uses: ./.github/actions/simple-build-alert
         continue-on-error: true
@@ -635,7 +635,7 @@ jobs:
     if: always() && inputs.infra-stage == 'stage-prod' && !startsWith(needs.decide-refs.outputs.monorepo, 'refs/tags/') && needs.run-build.result == 'success' && needs.decide-refs.outputs.variant == 'internal-release'
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: 'Send success alert'
         uses: ./.github/actions/simple-build-alert
         continue-on-error: true
@@ -658,7 +658,7 @@ jobs:
     if: always() && inputs.infra-stage == 'stage-prod' && !startsWith(needs.decide-refs.outputs.monorepo, 'refs/tags/') && needs.run-build.result == 'failure' && needs.decide-refs.outputs.variant == 'internal-release'
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: 'Send failure alert'
         uses: ./.github/actions/simple-build-alert
         continue-on-error: true
@@ -681,7 +681,7 @@ jobs:
     if: always() && inputs.infra-stage == 'stage-prod' && !startsWith(needs.decide-refs.outputs.monorepo, 'refs/tags/') && needs.run-build.result == 'cancelled' && needs.decide-refs.outputs.variant == 'internal-release'
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: 'Send cancelled alert'
         uses: ./.github/actions/simple-build-alert
         continue-on-error: true
@@ -704,7 +704,7 @@ jobs:
     if: always() && inputs.infra-stage == 'stage-prod' && !startsWith(needs.decide-refs.outputs.monorepo, 'refs/tags/') && needs.run-build.result == 'success' && needs.decide-refs.outputs.variant == 'release'
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: 'Send success alert'
         uses: ./.github/actions/simple-build-alert
         continue-on-error: true
@@ -727,7 +727,7 @@ jobs:
     if: always() && inputs.infra-stage == 'stage-prod' && !startsWith(needs.decide-refs.outputs.monorepo, 'refs/tags/') && needs.run-build.result == 'failure' && needs.decide-refs.outputs.variant == 'release'
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: 'Send failure alert'
         uses: ./.github/actions/simple-build-alert
         continue-on-error: true
@@ -750,7 +750,7 @@ jobs:
     if: always() && inputs.infra-stage == 'stage-prod' && !startsWith(needs.decide-refs.outputs.monorepo, 'refs/tags/') && needs.run-build.result == 'cancelled' && needs.decide-refs.outputs.variant == 'release'
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: 'Send cancelled alert'
         uses: ./.github/actions/simple-build-alert
         continue-on-error: true

--- a/.github/workflows/update-container.yaml
+++ b/.github/workflows/update-container.yaml
@@ -13,7 +13,7 @@ jobs:
       packages: write
       contents: read
     steps:
-      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: 'Build the container'
         id: container-build
         run: |


### PR DESCRIPTION
## Summary
- Bump remaining `actions/checkout@v3` pins in `build.yml` (ephemeral `run-build` checkouts) and `update-container.yaml` to the existing `v4.3.1` SHA pin.
- Normalize `# v4` comments to `# v4.3.1` where that SHA was already in use.
- Leave `checkout@v6` on `ubuntu-latest` (`initialize-infra`) unchanged; do **not** move ephemeral builders to checkout v5+ (Node 24 needs runner ≥ 2.327.1; current ephemeral runners are 2.317.0).

## Test plan
- [x] Push/CI: confirm zizmor / workflow security checks pass on this branch
- [ ] Dispatch an OT-2 image build against this buildroot ref and confirm `run-build` downloads `actions/checkout@v4.3.1` (not v3) with no Node runtime / runner version errors
- [ ] Confirm the three checkouts still succeed: workflow sources, buildroot overlay, monorepo (`opentrons` / `opentrons-ot2`)
- [ ] Confirm `steps.monorepo-checkout.outputs.commit` is still populated (used by release upload steps when `build-type == release`)
- [ ] On a tag push (or workflow_dispatch of `update-container`), confirm container build-push still checks out and runs